### PR TITLE
Fix bug when using more than one standalone worker

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -565,7 +565,7 @@ sub worker_temp_directory_name {
     my $self = shift @_;
 
     my $username = $ENV{'USER'};
-    my $worker_id = $self->worker ? $self->worker->dbID : 'standalone';
+    my $worker_id = $self->worker ? $self->worker->dbID : "standalone.$$";
     return "/tmp/worker_${username}.${worker_id}/";
 }
 


### PR DESCRIPTION
The worker_temp_directory for standalone workers was set to
/tmp/worker_${USER}.standalone. If two standalone workers were running
on the machine, they could overwrite each other’s files.
The fix include the process ID ($$ in Perl) in the directory name.
