### PR TITLE
fix warning "Use of uninitialized value in subroutine entry"

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils.pm
@@ -1,3 +1,4 @@
+
 =pod
 
 =head1 NAME
@@ -80,7 +81,7 @@ sub stringify {
     local $Data::Dumper::Quotekeys = 1;         # conserve some space
     local $Data::Dumper::Useqq     = 1;         # escape the \n and \t correctly
     local $Data::Dumper::Pair      = ' => ';    # make sure we always produce Perl-parsable structures, no matter what is set externally
-    local $Data::Dumper::Maxdepth  = -1;        # make sure nobody can mess up stringification by setting a lower Maxdepth
+    local $Data::Dumper::Maxdepth  = 0;         # make sure nobody can mess up stringification by setting a lower Maxdepth
 
     return Dumper($structure);
 }


### PR DESCRIPTION
Clears up the following warning from Data::Dumper when object properties end up undefined, in this case due to undef Maxdepth package variable.

```
Use of uninitialized value in subroutine entry at /software/perl/lib/perl5/x86_64-linux-thread-multi/Data/Dumper.pm line 224.
```
