### PR TITLE
Update init_pipeline.pl

### DIFF
--- a/scripts/init_pipeline.pl
+++ b/scripts/init_pipeline.pl
@@ -13,7 +13,9 @@ BEGIN {
     unshift @INC, $ENV{'EHIVE_ROOT_DIR'}.'/modules';
 }
 
-
+use Getopt::ArgvFile; # Enable passing of long commandline options by file. 
+                      # Example: perl init_pipeline.pl B::E::H::P::Whaterver_conf  @my_file.conf 
+                      # See CPAN Getopt::ArgvFile for more info. 
 use Getopt::Long qw(:config pass_through no_auto_abbrev);
 use Bio::EnsEMBL::Hive::Utils ('script_usage', 'load_file_or_module');
 use Bio::EnsEMBL::Hive::Scripts::InitPipeline;


### PR DESCRIPTION
Using Getopt::ArgvFile allows to pass long, complex commandline options via a file to init_pipeline.pl, so you can overwrite various options in your PipeConfig module without having super-long commandlines. We needed this as we run various pipelines with ever-changing options, and we do not want to change the installation of our pipelines all the time. 
Getopt::ArgvFile plays well with Getopt::Long and no additional changes are needed - well, except installing Getopt::ArgvFile ... 

USAGE: perl init_pipeline.pl Bio::EnsEMBL::Hive::PipeConfig:;Whaterver   @myconfigfile.conf 

The format of the configuration file you pass in is a key/value file :
--option value 
--option2 value2