### PR TITLE
Update LSF.pm to parse year- and year-less responses of LSF bacct cmd

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -224,7 +224,8 @@ sub parse_report_source_line {
             my (@keys, @values);
             my $line_has_key_values = 0;
             foreach (@lines) {
-                if( /^(\w+\s+\w+\s+\d+\s+\d+:\d+:\d+):\s+Completed\s<(\w+)>(?:\.|;\s+(\w+))/ ) {
+                // Parse yearless + year bacct response
+                if( /^(\w+\s+\w+\s+\d+\s+\d+:\d+:\d+)(?:\s*\d*):\s+Completed\s<(\w+)>(?:\.|;\s+(\w+))/ ) {
                     $when_died      = _yearless_2_datetime($1);
                     $cause_of_death = $3 && $status_2_cod{$3};
                     $exit_status = $2 . ($3 ? "/$3" : '');


### PR DESCRIPTION
Our installation of LSF returns the year in the bacct response - which is not parsed by the regex in parse_report_source_line(). The fix will parse year- and year-less responses of bacct. This is a quickfix as the _yearless_2_datetime() method is  still invoked - best would be to not invoke it if the year is returned; however I think it increases the complexity of the code too much.
Regex now parses both lines: 

```Sat Jan 23 22:48:28 2016: Completed <exit>; TERM_RUNLIMIT: job killed after reaching LSF run time limit.```

```Sat Jan 23 22:48:28: Completed <exit>; TERM_RUNLIMIT: job killed after reaching LSF run time limit.```

![screen shot 2016-01-26 at 4 06 05 pm](https://cloud.githubusercontent.com/assets/5687381/12600381/23e2be14-c44e-11e5-9932-c9bbba1262d5.jpg)

We're using LSF version 9.1.2.0 - would be interesting if the different response formats are due to different LSF versions. Maybe it's time to create Bio::EnsEMBL::Hive::Meadow::LSF::SUBVERSION ?