### PR TITLE
Fix for DS slow registry

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow.pm
@@ -203,48 +203,16 @@ sub get_current_worker_process_id {
 }
 
 
-=head2 count_pending_workers_by_rc_name
-
-    Title   :  count_pending_workers_by_rc_name
-    Function:  Called by the scheduler to decide how many more workers to
-               submit for each resource-class.
-
-=cut
-
-sub count_pending_workers_by_rc_name {
-    my ($self) = @_;
-
-    die "Please use a derived method";
-}
-
-
-=head2 count_running_workers
-
-    Title   :  count_running_workers
-    Function:  Called by the scheduler to decide the number of additional
-               workers that can be submitted (within the defined
-               capacities).
-
-=cut
-
-sub count_running_workers {
-    my ($self, $meadow_users_of_interest) = @_;
-
-    die "Please use a derived method";
-}
-
-
 =head2 status_of_all_our_workers
 
     Title   :  status_of_all_our_workers
-    Function:  Returns a hashref that maps workers' process_id to their status.
-               Statuses are mainly free-text strings. Only "UNKWN" is a special
-               status that beekeeper can understand.
-               Typical statuses are "RUN", "PEND", "SSUSP", "UNKWN"
+    Function:  Returns an arrayref of arrayrefs [worker_pid, meadow_user, status, rc_name]
+               listing the workers that this Meadow can see.
+               Allowed statuses are "RUN", "PEND", "SSUSP", "UNKWN"
 
 =cut
 
-sub status_of_all_our_workers { # returns a hashref
+sub status_of_all_our_workers { # returns an arrayref
     my ($self, $meadow_users_of_interest) = @_;
 
     die "Please use a derived method";

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -71,59 +71,13 @@ sub get_current_worker_process_id {
 }
 
 
-sub count_pending_workers_by_rc_name {
-    my ($self) = @_;
-
-    my $jnp = $self->job_name_prefix();
-    my $cmd = "bjobs -w -J '${jnp}*' 2>/dev/null | grep PEND";  # "-u all" has been removed to ensure one user's PEND processes
-                                                                #   do not affect another user helping to run the same pipeline.
-
-#    warn "LSF::count_pending_workers_by_rc_name() running cmd:\n\t$cmd\n";
-
-    my %pending_this_meadow_by_rc_name = ();
-    my $total_pending_this_meadow = 0;
-
-    foreach my $line (qx/$cmd/) {
-        if($line=~/\b\Q$jnp\E(\S+)\-\d+(\[\d+\])?\b/) {
-            $pending_this_meadow_by_rc_name{$1}++;
-            $total_pending_this_meadow++;
-        }
-    }
-
-    return (\%pending_this_meadow_by_rc_name, $total_pending_this_meadow);
-}
-
-
-sub count_running_workers {
+sub status_of_all_our_workers { # returns an arrayref
     my $self                        = shift @_;
     my $meadow_users_of_interest    = shift @_ || [ 'all' ];
 
     my $jnp = $self->job_name_prefix();
 
-    my $total_running_worker_count = 0;
-
-    foreach my $meadow_user (@$meadow_users_of_interest) {
-        my $cmd = "bjobs -w -J '${jnp}*' -u $meadow_user 2>/dev/null | grep RUN | wc -l";
-
-#        warn "LSF::count_running_workers() running cmd:\n\t$cmd\n";
-
-        my $meadow_user_worker_count = qx/$cmd/;
-        chomp($meadow_user_worker_count);
-
-        $total_running_worker_count += $meadow_user_worker_count;
-    }
-
-    return $total_running_worker_count;
-}
-
-
-sub status_of_all_our_workers { # returns a hashref
-    my $self                        = shift @_;
-    my $meadow_users_of_interest    = shift @_ || [ 'all' ];
-
-    my $jnp = $self->job_name_prefix();
-
-    my %status_hash = ();
+    my @status_list = ();
 
     foreach my $meadow_user (@$meadow_users_of_interest) {
         my $cmd = "bjobs -w -J '${jnp}*' -u $meadow_user 2>/dev/null";
@@ -139,11 +93,15 @@ sub status_of_all_our_workers { # returns a hashref
             if($job_name=~/(\[\d+\])$/ and $worker_pid!~/\[\d+\]$/) {   # account for the difference in LSF 9.1.1.1 vs LSF 9.1.2.0  bjobs' output
                 $worker_pid .= $1;
             }
-            $status_hash{$worker_pid} = $status;
+            my $rc_name = '__unknown_rc_name__';
+            if ($job_name =~ /^\Q$jnp\E(\S+)\-\d+(\[\d+\])?$/) {
+                $rc_name = $1;
+            }
+            push @status_list, [$worker_pid, $user, $status, $rc_name];
         }
     }
 
-    return \%status_hash;
+    return \@status_list;
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Scheduler.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scheduler.pm
@@ -56,11 +56,13 @@ sub scheduler_say {
 sub schedule_workers_resync_if_necessary {
     my ($queen, $valley, $list_of_analyses) = @_;
 
-    my $meadow_type_2_name_2_users              = $queen->meadow_type_2_name_2_users_of_running_workers();
+    my $all_registered_running_workers          = $queen->running_process_ids_hashed_by_meadow_parameters();
+    my $statuses                                = $valley->query_worker_statuses($all_registered_running_workers);
+
     my $submit_capacity                         = $valley->config_get('SubmitWorkersMax');
     my $default_meadow_type                     = $valley->get_default_meadow()->type;
     my ($valley_running_worker_count,
-        $meadow_capacity_limiter_hashed_by_type)= $valley->count_running_workers_and_generate_limiters( $meadow_type_2_name_2_users );
+        $meadow_capacity_limiter_hashed_by_type)= $valley->generate_limiters( $statuses );
 
     my ($workers_to_submit_by_analysis, $workers_to_submit_by_meadow_type_rc_name, $total_extra_workers_required, $log_buffer)
         = schedule_workers($queen, $submit_capacity, $default_meadow_type, $list_of_analyses, $meadow_capacity_limiter_hashed_by_type);
@@ -103,7 +105,7 @@ sub schedule_workers_resync_if_necessary {
     }
 
         # adjustment for pending workers:
-    my ($pending_worker_counts_by_meadow_type_rc_name, $total_pending_all_meadows)  = $valley->get_pending_worker_counts_by_meadow_type_rc_name();
+    my ($pending_worker_counts_by_meadow_type_rc_name, $total_pending_all_meadows)  = $valley->get_pending_worker_counts_by_meadow_type_rc_name($statuses);
 
     while( my ($this_meadow_type, $partial_workers_to_submit_by_rc_name) = each %$workers_to_submit_by_meadow_type_rc_name) {
         while( my ($this_rc_name, $workers_to_submit_this_group) = each %$partial_workers_to_submit_by_rc_name) {

--- a/t/04.meadow/lsf.t
+++ b/t/04.meadow/lsf.t
@@ -20,7 +20,7 @@ use warnings;
 use Cwd;
 use File::Basename;
 
-use Test::More tests => 20;
+use Test::More tests => 17;
 use Test::Exception;
 
 use Bio::EnsEMBL::Hive::Utils::Config;
@@ -62,60 +62,54 @@ subtest 'get_current_worker_process_id()' => sub
 };
 
 is_deeply(
-    [$lsf_meadow->count_pending_workers_by_rc_name],
-    [ { 'normal_30GB_2cpu' => 2, 'normal_10gb' => 7 }, 9 ],
-    'count_pending_workers_by_rc_name()',
-);
-
-is($lsf_meadow->count_running_workers, 26, 'count_running_workers()');
-is($lsf_meadow->count_running_workers(['il4']), 24, 'count_running_workers("il4")');
-
-is_deeply(
     $lsf_meadow->status_of_all_our_workers,
-    {
-        '2068349[1]' => 'RUN',
-        '2067769[11]' => 'RUN',
-        '2067765[4]' => 'RUN',
-        '2067754[31]' => 'RUN',
-        '2068245' => 'RUN',
-        '2067754[27]' => 'RUN',
-        '2067769[2]' => 'RUN',
-        '2068349[2]' => 'RUN',
-        '2067769[14]' => 'RUN',
-        '2067754[32]' => 'RUN',
-        '2067754[34]' => 'RUN',
-        '2067754[7]' => 'RUN',
-        '2067769[10]' => 'RUN',
-        '2067769[3]' => 'PEND',
-        '2067769[9]' => 'RUN',
-        '2067769[17]' => 'PEND',
-        '2067754[14]' => 'RUN',
-        '2067769[4]' => 'PEND',
-        '2067769[6]' => 'PEND',
-        '2068410' => 'PEND',
-        '2067769[19]' => 'PEND',
-        '2067769[18]' => 'PEND',
-        '2067754[30]' => 'RUN',
-        '2067769[12]' => 'RUN',
-        '2067754[26]' => 'RUN',
-        '2067765[13]' => 'RUN',
-        '2068463' => 'PEND',
-        '2067769[13]' => 'RUN',
-        '2067769[15]' => 'RUN',
-        '2067769[16]' => 'RUN',
-        '2067769[8]' => 'RUN',
-        '2067754[28]' => 'RUN',
-        '2067754[33]' => 'RUN',
-        '2067769[5]' => 'PEND',
-        '276335[13]' => 'RUN',
-    },
+    [
+        [ '2067769[9]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[10]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[11]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[12]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[13]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[8]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[26]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[27]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[28]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[30]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[31]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[32]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[33]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067754[34]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067765[4]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067765[13]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2068245', 'mm14', 'RUN', 'normal_30GB_2cpu' ],
+        [ '2068410', 'il4', 'PEND', 'normal_30GB_2cpu' ],
+        [ '2067769[14]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[15]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2068463', 'mm14', 'PEND', 'normal_30GB_2cpu' ],
+        [ '2067754[14]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2068349[2]', 'il4', 'RUN', 'normal_30GB_2cpu' ],
+        [ '2067769[16]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[17]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[18]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[19]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[6]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[3]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[4]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2067769[5]', 'il4', 'PEND', 'normal_10gb' ],
+        [ '2068349[1]', 'il4', 'RUN', 'normal_30GB_2cpu' ],
+        [ '2067754[7]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '2067769[2]', 'il4', 'RUN', 'normal_10gb' ],
+        [ '276335[13]', 'tmpseq', 'RUN', 'verylong_rc' ]
+    ],
     'status_of_all_our_workers()',
 );
 
 is_deeply(
     $lsf_meadow->status_of_all_our_workers(["mm14"]),
-    { '2068245' => 'RUN', '2068463' => 'PEND' },
-    'status_of_all_our_workers("mm14")',
+    [
+        [ '2068245', 'mm14', 'RUN', 'normal_30GB_2cpu' ],
+        [ '2068463', 'mm14', 'PEND', 'normal_30GB_2cpu' ]
+    ],
+    'status_of_all_our_workers(["mm14"])',
 );
 
 use Bio::EnsEMBL::Hive::Worker;

--- a/t/04.meadow/valley.t
+++ b/t/04.meadow/valley.t
@@ -36,7 +36,7 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 my @config_files = Bio::EnsEMBL::Hive::Utils::Config->default_config_files();
 my $config = Bio::EnsEMBL::Hive::Utils::Config->new(@config_files);
 
-my @virtual_methods = qw(name get_current_worker_process_id count_running_workers count_pending_workers_by_rc_name status_of_all_our_workers check_worker_is_alive_and_mine kill_worker submit_workers);
+my @virtual_methods = qw(name get_current_worker_process_id status_of_all_our_workers check_worker_is_alive_and_mine kill_worker submit_workers);
 
 # Check that the base Meadow class has some virtual methods
 subtest 'Bio::EnsEMBL::Hive::Meadow' => sub {


### PR DESCRIPTION
This fixes @danstaines's issue:
[Feb 11th at 09:49]
I've got a problem with hive where I supply a registry, and the registry takes a couple of minutes to load (this is normal with 40k bacteria unfortunately).

The registry takes a lot of time to load, so the worker is running from the LSF point-of-view but is not registered in the database yet (because the DBAdaptor object is not ready yet). Because of the discrepancy, beekeeper thinks that nothing is running and keep on submitting new workers (beyond the analysis capacity)

My fix is to basically count those workers as _pending_. Because the Valley/Meadow had a method to get the running workers and another one to get the pending workers, I had to unify them into a single method that takes the list of the workers that have registered and return the correct counts. This super-hash is then carried around in various places so that all the decisions are consistent to each other. Overall the Valley now does more things and the Meadows are a bit shorter
