### PR TITLE
Use File::Glob to get the list of filenames

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/SqlSchemaAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/SqlSchemaAdaptor.pm
@@ -38,12 +38,14 @@ package Bio::EnsEMBL::Hive::DBSQL::SqlSchemaAdaptor;
 use strict;
 use warnings;
 
+use File::Glob qw(bsd_glob);
+
 sub find_all_sql_schema_patches {
 
     my %all_patches = ();
 
     if(my $hive_root_dir = $ENV{'EHIVE_ROOT_DIR'} ) {
-        foreach my $patch_path ( split(/\n/, `ls -1 $hive_root_dir/sql/patch_20*.*sql*`) ) {
+        foreach my $patch_path ( glob "'$hive_root_dir/sql/patch_20*.*sql*'" ) {
             my ($patch_name, $driver) = ($patch_path=~/^(.+)\.(\w+)$/);
 
             $driver = 'mysql' if ($driver eq 'sql');    # for backwards compatibility

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/SqlSchemaAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/SqlSchemaAdaptor.pm
@@ -45,7 +45,7 @@ sub find_all_sql_schema_patches {
     my %all_patches = ();
 
     if(my $hive_root_dir = $ENV{'EHIVE_ROOT_DIR'} ) {
-        foreach my $patch_path ( glob "'$hive_root_dir/sql/patch_20*.*sql*'" ) {
+        foreach my $patch_path ( glob "$hive_root_dir/sql/patch_20*.*sql*" ) {
             my ($patch_name, $driver) = ($patch_path=~/^(.+)\.(\w+)$/);
 
             $driver = 'mysql' if ($driver eq 'sql');    # for backwards compatibility


### PR DESCRIPTION
Previously backtick ls command was used to fetch the list of sql patches filenames.
By using backtick it is required to fork a new process. This would potentially be
a problem for a running process that uses large amount of memory. If there is not
enough spare memory left in the system, the fork operation could be aborted because
of "cannot allocate memory" error.

Fixes ENSEMBL-4823.