### PR TITLE
More options when running system commands

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -597,9 +597,24 @@ sub throw {
 }
 
 
-sub complete_early {
-    my ($self, $msg) = @_;
+=head2 complete_early
 
+  Arg[1]      : (string) message
+  Arg[2]      : (integer, optional) branch number
+  Description : Ends the job with the given message, whilst marking the job as complete
+                Dataflows to the given branch right before if a branch number if given,
+                in which case the autoflow is disabled too.
+  Returntype  : This function does not return
+
+=cut
+
+sub complete_early {
+    my ($self, $msg, $branch_code) = @_;
+
+    if (defined $branch_code) {
+        $self->dataflow_output_id(undef, $branch_code);
+        $self->input_job->autoflow(0);
+    }
     $self->input_job->incomplete(0);
     die $msg;
 }

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -480,12 +480,12 @@ sub run_system_command {
 
     # Capture:Tiny has weird behavior if 'require'd instead of 'use'd
     # see, for example,http://www.perlmonks.org/?node_id=870439 
-    my $stderr = Capture::Tiny::tee_stderr(sub {
+    my ($stdout, $stderr) = Capture::Tiny::tee(sub {
         $return_value = timeout( sub {system(@cmd_to_run)}, $options->{'timeout'} );
     });
     die sprintf("Could not run '%s', got %s\nSTDERR %s\n", $flat_cmd, $return_value, $stderr) if $return_value && $options->{die_on_failure};
 
-    return ($return_value, $stderr, $flat_cmd) if wantarray;
+    return ($return_value, $stderr, $flat_cmd, $stdout) if wantarray;
     return $return_value;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -103,6 +103,7 @@ use warnings;
 
 use JSON;
 use Scalar::Util qw(looks_like_number);
+use Time::HiRes qw(time);
 
 use Bio::EnsEMBL::Hive::Utils ('stringify', 'go_figure_dbc', 'join_command_args', 'timeout');
 use Bio::EnsEMBL::Hive::Utils::Stopwatch;
@@ -480,12 +481,13 @@ sub run_system_command {
 
     # Capture:Tiny has weird behavior if 'require'd instead of 'use'd
     # see, for example,http://www.perlmonks.org/?node_id=870439 
+    my $starttime = time() * 1000;
     my ($stdout, $stderr) = Capture::Tiny::tee(sub {
         $return_value = timeout( sub {system(@cmd_to_run)}, $options->{'timeout'} );
     });
     die sprintf("Could not run '%s', got %s\nSTDERR %s\n", $flat_cmd, $return_value, $stderr) if $return_value && $options->{die_on_failure};
 
-    return ($return_value, $stderr, $flat_cmd, $stdout) if wantarray;
+    return ($return_value, $stderr, $flat_cmd, $stdout, time()*1000-$starttime) if wantarray;
     return $return_value;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
@@ -88,13 +88,14 @@ sub run {
     my $self = shift;
  
     my %transferred_options = map {$_ => $self->param($_)} qw(use_bash_pipefail use_bash_errexit timeout);
-    my ($return_value, $stderr, $flat_cmd, $stdout) = $self->run_system_command($self->param_required('cmd'), \%transferred_options);
+    my ($return_value, $stderr, $flat_cmd, $stdout, $runtime_msec) = $self->run_system_command($self->param_required('cmd'), \%transferred_options);
 
     # To be used in write_output()
     $self->param('return_value', $return_value);
     $self->param('stderr', $stderr);
     $self->param('flat_cmd', $flat_cmd);
     $self->param('stdout', $stdout);
+    $self->param('runtime_msec', $runtime_msec);
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
@@ -137,9 +137,7 @@ sub write_output {
         # We create a dataflow event depending on the exit code of the process.
         if (ref($self->param('return_codes_2_branches')) and exists $self->param('return_codes_2_branches')->{$return_value}) {
             my $branch_number = $self->param('return_codes_2_branches')->{$return_value};
-            $self->dataflow_output_id( undef, $branch_number );
-            $self->input_job->autoflow(0);
-            $self->complete_early(sprintf("The command exited with code %d, which is mapped to a dataflow on branch #%d.\n", $return_value, $branch_number));
+            $self->complete_early(sprintf("The command exited with code %d, which is mapped to a dataflow on branch #%d.\n", $return_value, $branch_number), $branch_number);
         }
 
         if ($stderr =~ /Exception in thread ".*" java.lang.OutOfMemoryError: Java heap space at/) {

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
@@ -88,12 +88,13 @@ sub run {
     my $self = shift;
  
     my %transferred_options = map {$_ => $self->param($_)} qw(use_bash_pipefail use_bash_errexit timeout);
-    my ($return_value, $stderr, $flat_cmd) = $self->run_system_command($self->param_required('cmd'), \%transferred_options);
+    my ($return_value, $stderr, $flat_cmd, $stdout) = $self->run_system_command($self->param_required('cmd'), \%transferred_options);
 
     # To be used in write_output()
     $self->param('return_value', $return_value);
     $self->param('stderr', $stderr);
     $self->param('flat_cmd', $flat_cmd);
+    $self->param('stdout', $stdout);
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -140,7 +140,7 @@ sub standaloneJob {
     subtest "standalone run of $module_or_file" => sub {
         plan tests => 2 + ($expected_events ? 1+scalar(@$expected_events) : 0);
         lives_ok(sub {
-            my $is_success = Bio::EnsEMBL::Hive::Scripts::StandaloneJob::standaloneJob($module_or_file, $input_id, $flags, undef, $flags->{language});
+            my $is_success = Bio::EnsEMBL::Hive::Scripts::StandaloneJob::standaloneJob($module_or_file, $input_id, $flags, $flags->{flow_into}, $flags->{language});
             if ($flags->{expect_failure}) {
                 ok(!$is_success, 'job failed as expected');
             } else {

--- a/t/05.runnabledb/systemcmd.t
+++ b/t/05.runnabledb/systemcmd.t
@@ -80,6 +80,11 @@ standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             'INFO'
         ],
     ],
+    {
+        'flow_into' => {
+                '-1' => [ 'dummy' ],
+            },
+    },
 );
 
 

--- a/t/05.runnabledb/systemcmd.t
+++ b/t/05.runnabledb/systemcmd.t
@@ -88,6 +88,30 @@ standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
 );
 
 
+# Here we pretend we have a command that takes to omuch time to complete
+$input_hash = { 'cmd' => 'sleep 10', 'timeout' => 3 };
+standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+    $input_hash,
+    [
+        [
+            'DATAFLOW',
+            undef,
+            -2,
+        ],
+        [
+            'WARNING',
+            qr/The command was aborted because it exceeded the allowed runtime. Flowing to the -2 branch/,
+            'INFO'
+        ],
+    ],
+    {
+        'flow_into' => {
+                '-2' => [ 'dummy' ],
+            },
+    },
+);
+
+
 # This is expected to complete succesfully since the return status of a
 # pipe is the last command's
 standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::SystemCmd', {


### PR DESCRIPTION
I've added a few options in `Process::run_system_command` and `RunnaleDB::SystemCmd` to:
- add a time limit (mimicking LSF's _RUNLIMIT_)
- capture the standard output
- record how long the command took