### PR TITLE
Consistently print messages to stdout

### DIFF
--- a/docs/advanced_usage/mpi.rst
+++ b/docs/advanced_usage/mpi.rst
@@ -1,3 +1,6 @@
+
+.. _howto-mpi:
+
 How to use MPI
 ==============
 
@@ -191,6 +194,8 @@ Runnable.
             'cmd' => 'cmd 1 ; cmd  2 ; #mpirun_exe# #examl_exe# -examl_parameter_1 value1 -examl_parameter_2 value2',
         };
     }
+
+.. _worker_temp_directory_name-mpi:
 
 Temporary files
 ~~~~~~~~~~~~~~~

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -6,32 +6,87 @@ eHive exposes an interface for Runnables (jobs) to interact with the
 system:
 
   - query their own parameters. See :ref:`parameters-in-jobs`
-  - control its own execution
-  - report issues
-  - run commands
+  - control its own execution and report issues
+  - run system commands
   - trigger some *dataflow* events (e.g. create new jobs)
 
-
-Execution control
------------------
-
-- worker_temp_directory
-- worker_temp_directory_name
-- cleanup_worker_temp_directory
 
 Reporting and logging
 ---------------------
 
-- warning
-- say_with_header
-- throw
-- complete_early
-- debug
+Jobs can log messages to the standard output with the
+``$self->say_with_header($message, $important)`` method. However they are only printed
+when the *debug* mode is enabled (see below) or when the ``$important`` flag is switched on.
+They will also be prefixed with a standard prefix consisting of the
+runtime context (worker, role, job).
 
-System commands
----------------
+The debug mode is controlled by the ``--debug X`` option of
+:ref:`script-beekeeper` and :ref:`script-runWorker`. *X* is an integer,
+allowing multiple levels of debug, although most of the modules will only
+check whether it is 0 or not.
 
-- run_system_command
+``$self->warning($message)`` calls ``$self->say_with_header($message, 1)``
+(so that the messages are printed on the standard output) but also stores
+them in the database (in the ``log_message`` table).
+
+To indicate that a job has to be terminated earlier (i.e. before reaching
+the end of ``write_output``), you can call:
+
+- ``$self->complete_early($message)`` to mark the job as *DONE*
+  (successful run). Beware that this will trigger the *autoflow*.
+- ``$self->throw($message)`` to log a failed attempt. The job may be given
+  additional retries following the analysis' *max_retry_count* parameter,
+  or is marked as *FAILED* in the database.
+
+System interactions
+-------------------
+
+All Runnables have access to the ``$self->run_system_command`` method to run
+arbitrary system commands (the ``SystemCmd`` Runnable is merely a wrapper
+around this method).
+
+``run_system_command`` takes two arguments:
+
+#. The command to run, given as a single string or an arrayref. Arrayrefs
+   are the preferred way as they simplify the handling of whitespace and
+   quotes in the command-line arguments. Arrayrefs that correspond to
+   straightforward commands, e.g. ``['find', '-type', 'd']``, are passed to
+   the underlying ``system`` function as lists. Arrayrefs can contain shell
+   meta-characters and delimiters such as ``>`` (to redirect the output to a
+   file), ``;`` (to separate two commands that have to be run sequentially)
+   or ``|`` (a pipe) and will be quoted and joined and passed to ``system``
+   as a single string
+#. An hashref of options. Accepted options are:
+
+   - ``use_bash_pipefail``: Normally, the exit status of a pipeline (e.g.
+     ``cmd1 | cmd2`` is the exit status of the last command, meaning that
+     errors in the first command are not captured. With the option turned
+     on, the exit status of the pipeline will capture errors in any command
+     of the pipeline, and will only be 0 if *all* the commands exit
+     successfully
+   - ``use_bash_errexit``: Exit immediately if a command fails. This is
+     mostly useful for cases like ``cmd1; cmd2`` where by default, ``cmd2``
+     would always be executed, regardless of the exit status of ``cmd1``
+   - ``timeout``: the maximum number of seconds the command is allowed to
+     run for. The exit status will be set to -2 if the command had to be
+     aborted
+
+During their execution, jobs may certainly have to use temporary files.
+eHive provides a directory that will exist throughout the lifespan of the
+worker with the ``$self->worker_temp_directory`` method. The directory is created
+the first time the method is called, and deleted when the worker ends. It is the Runnable's
+responsibility to leave the directory in a clean-enough state for the next
+job (by removing some files, for instance), or to clean it up completely
+with ``$self->cleanup_worker_temp_directory``.
+
+By default, this directory will be put under /tmp, but it can be overriden
+by adding a ``worker_temp_directory_name`` method to the runnable. This can
+be used to:
+
+- use a faster filesystem (although /tmp is usually local to the machine)
+- use a network filesystem (needed for distributed applications, e.g. over
+  MPI). See :ref:`worker_temp_directory_name-mpi` in the :ref:`howto-mpi` section.
+
 
 Dataflows
 ---------
@@ -41,7 +96,7 @@ are immediately reacted upon. The main event is called **Dataflow** (see
 :ref:`dataflows` for more information) and
 consists of sending some data somewhere. The destination of a Dataflow
 event must be defined in the pipeline graph itself, and is then referred to
-by a *branch number* (see :ref:`dataflows`).
+by a *branch number*.
 
 Within a Runnable, Dataflow events are performed via the ``$self->dataflow_output_id($data,
 $branch_number)`` method.
@@ -55,8 +110,8 @@ The payload ``$data`` must be of one of these types:
 The branch number defaults to 1 and can be skipped. Generally speaking, it
 has to be an integer.
 
-Runnables can also use ``dataflow_output_ids_from_json($filename, $default_branch)``.
-This method simply wraps ``dataflow_output_id``, allowing external programs
+Runnables can also use ``$self->dataflow_output_ids_from_json($filename, $default_branch)``.
+This method simply wraps ``$self->dataflow_output_id``, allowing external programs
 to easily generate events. The method takes two arguments:
 
 #. The path to a file containing one JSON object per line. Each line can be

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -96,11 +96,11 @@ Dataflows
 ---------
 
 eHive is an *event-driven* system whereby agents trigger events that
-are immediately reacted upon. The main event is called **Dataflow** (see
+are immediately reacted upon. The main event is called "Dataflow" (see
 :ref:`dataflows` for more information) and
 consists of sending some data somewhere. The destination of a Dataflow
 event must be defined in the pipeline graph itself, and is then referred to
-by a *branch number*.
+by a "branch number".
 
 Within a Runnable, Dataflow events are performed via the ``$self->dataflow_output_id($data,
 $branch_number)`` method.

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -34,6 +34,9 @@ the end of ``write_output``), you can call:
 
 - ``$self->complete_early($message)`` to mark the job as *DONE*
   (successful run). Beware that this will trigger the *autoflow*.
+- ``$self->complete_early($message, $branch_code)`` is a variation of the
+  above that will replace the autoflow (branch 1) with a dataflow on the
+  branch given
 - ``$self->throw($message)`` to log a failed attempt. The job may be given
   additional retries following the analysis' *max_retry_count* parameter,
   or is marked as *FAILED* in the database.

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -5,10 +5,10 @@ Runnable API
 eHive exposes an interface for Runnables (jobs) to interact with the
 system:
 
-  - query their own parameters. See :ref:`parameters-in-jobs`
-  - control its own execution and report issues
-  - run system commands
-  - trigger some *dataflow* events (e.g. create new jobs)
+  - query their own parameters (see :ref:`parameters-in-jobs`),
+  - control its own execution and report issues,
+  - run system commands,
+  - trigger some *dataflow* events (e.g. create new jobs).
 
 
 Reporting and logging
@@ -18,7 +18,7 @@ Jobs can log messages to the standard output with the
 ``$self->say_with_header($message, $important)`` method. However they are only printed
 when the *debug* mode is enabled (see below) or when the ``$important`` flag is switched on.
 They will also be prefixed with a standard prefix consisting of the
-runtime context (worker, role, job).
+runtime context (Worker, Role, Job).
 
 The debug mode is controlled by the ``--debug X`` option of
 :ref:`script-beekeeper` and :ref:`script-runWorker`. *X* is an integer,
@@ -29,16 +29,16 @@ check whether it is 0 or not.
 (so that the messages are printed on the standard output) but also stores
 them in the database (in the ``log_message`` table).
 
-To indicate that a job has to be terminated earlier (i.e. before reaching
+To indicate that a Job has to be terminated earlier (i.e. before reaching
 the end of ``write_output``), you can call:
 
-- ``$self->complete_early($message)`` to mark the job as *DONE*
+- ``$self->complete_early($message)`` to mark the Job as *DONE*
   (successful run) and record the message in the database. Beware that this
   will trigger the *autoflow*.
 - ``$self->complete_early($message, $branch_code)`` is a variation of the
   above that will replace the autoflow (branch 1) with a dataflow on the
-  branch given
-- ``$self->throw($message)`` to log a failed attempt. The job may be given
+  branch given.
+- ``$self->throw($message)`` to log a failed attempt. The Job may be given
   additional retries following the analysis' *max_retry_count* parameter,
   or is marked as *FAILED* in the database.
 
@@ -59,7 +59,7 @@ around this method).
    meta-characters and delimiters such as ``>`` (to redirect the output to a
    file), ``;`` (to separate two commands that have to be run sequentially)
    or ``|`` (a pipe) and will be quoted and joined and passed to ``system``
-   as a single string
+   as a single string.
 #. An hashref of options. Accepted options are:
 
    - ``use_bash_pipefail``: Normally, the exit status of a pipeline (e.g.
@@ -67,27 +67,27 @@ around this method).
      errors in the first command are not captured. With the option turned
      on, the exit status of the pipeline will capture errors in any command
      of the pipeline, and will only be 0 if *all* the commands exit
-     successfully
+     successfully.
    - ``use_bash_errexit``: Exit immediately if a command fails. This is
      mostly useful for cases like ``cmd1; cmd2`` where by default, ``cmd2``
-     would always be executed, regardless of the exit status of ``cmd1``
+     would always be executed, regardless of the exit status of ``cmd1``.
    - ``timeout``: the maximum number of seconds the command is allowed to
      run for. The exit status will be set to -2 if the command had to be
-     aborted
+     aborted.
 
 During their execution, jobs may certainly have to use temporary files.
 eHive provides a directory that will exist throughout the lifespan of the
-worker with the ``$self->worker_temp_directory`` method. The directory is created
-the first time the method is called, and deleted when the worker ends. It is the Runnable's
+Worker with the ``$self->worker_temp_directory`` method. The directory is created
+the first time the method is called, and deleted when the Worker ends. It is the Runnable's
 responsibility to leave the directory in a clean-enough state for the next
-job (by removing some files, for instance), or to clean it up completely
+Job (by removing some files, for instance), or to clean it up completely
 with ``$self->cleanup_worker_temp_directory``.
 
 By default, this directory will be put under /tmp, but it can be overriden
 by adding a ``worker_temp_directory_name`` method to the runnable. This can
 be used to:
 
-- use a faster filesystem (although /tmp is usually local to the machine)
+- use a faster filesystem (although /tmp is usually local to the machine),
 - use a network filesystem (needed for distributed applications, e.g. over
   MPI). See :ref:`worker_temp_directory_name-mpi` in the :ref:`howto-mpi` section.
 
@@ -107,9 +107,9 @@ $branch_number)`` method.
 
 The payload ``$data`` must be of one of these types:
 
-- Hash-reference that maps parameter names (strings) to their values.
-- Array-reference of hash-references of the above type
-- ``undef`` to propagate the job's input_id
+- hash-reference that maps parameter names (strings) to their values,
+- array-reference of hash-references of the above type,
+- ``undef`` to propagate the job's input_id.
 
 The branch number defaults to 1 and can be skipped. Generally speaking, it
 has to be an integer.
@@ -121,6 +121,6 @@ to easily generate events. The method takes two arguments:
 #. The path to a file containing one JSON object per line. Each line can be
    prefixed with a branch number (and some whitespace), which will override
    the default branch number.
-#. The default branch number (defaults to 1 too)
+#. The default branch number (defaults to 1 too).
 
 

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -33,7 +33,8 @@ To indicate that a job has to be terminated earlier (i.e. before reaching
 the end of ``write_output``), you can call:
 
 - ``$self->complete_early($message)`` to mark the job as *DONE*
-  (successful run). Beware that this will trigger the *autoflow*.
+  (successful run) and record the message in the database. Beware that this
+  will trigger the *autoflow*.
 - ``$self->complete_early($message, $branch_code)`` is a variation of the
   above that will replace the autoflow (branch 1) with a dataflow on the
   branch given

--- a/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
+++ b/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
@@ -189,10 +189,10 @@ sub new {
 
     my $protocol_debug = ($debug && ($debug > 1));  # Only advanced levels of debug will show the GuestProcess protocol messages
     if ($protocol_debug) {
-        print STDERR "PARENT_RDR is ", fileno($PARENT_RDR), "\n";
-        print STDERR "PARENT_WTR is ", fileno($PARENT_WTR), "\n";
-        print STDERR "CHILD_RDR is ", fileno($CHILD_RDR), "\n";
-        print STDERR "CHILD_WTR is ", fileno($CHILD_WTR), "\n";
+        print "PARENT_RDR is ", fileno($PARENT_RDR), "\n";
+        print "PARENT_WTR is ", fileno($PARENT_WTR), "\n";
+        print "CHILD_RDR is ", fileno($CHILD_RDR), "\n";
+        print "CHILD_WTR is ", fileno($CHILD_WTR), "\n";
     }
 
     my $pid;
@@ -201,13 +201,13 @@ sub new {
         # In the parent
         close $PARENT_RDR;
         close $PARENT_WTR;
-        print STDERR "parent is PID $$\n" if $protocol_debug;
+        print "parent is PID $$\n" if $protocol_debug;
     } else {
         die "cannot fork: $!" unless defined $pid;
         # In the child
         close $CHILD_RDR;
         close $CHILD_WTR;
-        print STDERR "child is PID $$\n" if $protocol_debug;
+        print "child is PID $$\n" if $protocol_debug;
 
         # Do not close the non-standard file descriptors on exec(): the child process will need them !
         use Fcntl;
@@ -325,7 +325,7 @@ sub DESTROY {
 
 sub print_debug {
     my ($self, $msg) = @_;
-    print STDERR sprintf("PERL %d: %s\n", $self->child_pid, $msg) if $self->{'_protocol_debug'};
+    print sprintf("PERL %d: %s\n", $self->child_pid, $msg) if $self->{'_protocol_debug'};
 }
 
 ##############

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
@@ -150,7 +150,7 @@ sub submit_workers_return_meadow_pids {
 
     my @children_pids = ();
 
-    warn "Spawning [ ".$self->signature." ] x$required_worker_count \t\t$worker_cmd\n";
+    print "Spawning [ ".$self->signature." ] x$required_worker_count \t\t$worker_cmd\n";
 
     foreach my $idx (1..$required_worker_count) {
 

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -196,7 +196,7 @@ sub _convert_to_datetime {      # a private subroutine that can recover missing 
 sub parse_report_source_line {
     my ($self, $bacct_source_line) = @_;
 
-    warn "LSF::parse_report_source_line( \"$bacct_source_line\" )\n";
+    print "LSF::parse_report_source_line( \"$bacct_source_line\" )\n";
 
     # Conplete list of exit codes is available at
     # https://www.ibm.com/support/knowledgecenter/SSETD4_9.1.3/lsf_admin/termination_reasons_lsf.html
@@ -365,7 +365,7 @@ sub submit_workers_return_meadow_pids {
         $worker_cmd
     );
 
-    warn "Executing [ ".$self->signature." ] \t\t".join(' ', @cmd)."\n";
+    print "Executing [ ".$self->signature." ] \t\t".join(' ', @cmd)."\n";
 
     my $lsf_jobid;
 

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -212,7 +212,7 @@ sub say_with_header {
         if(my $worker = $self->worker) {
             $worker->worker_say( $msg );
         } else {
-            print STDERR "StandaloneJob $msg\n";
+            print "StandaloneJob $msg\n";
         }
     }
 }

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
@@ -175,7 +175,7 @@ sub fetch_input {
 
     # Get the table list in either "tables" or "ignores"
     my $table_list = $self->_get_table_list($src_dbc, $self->param('table_list') || '');
-    print "table_list: ", scalar(@$table_list), " ", join('/', @$table_list), "\n" if $self->debug;
+    $self->say_with_header(sprintf("table_list: %d %s\n", scalar(@$table_list), join('/', @$table_list)));
     my $nothing_to_dump = 0;
 
     if ($self->param('exclude_list')) {
@@ -205,14 +205,14 @@ sub fetch_input {
 
     $self->input_job->transient_error(1);
 
-    print "tables: ", scalar(@tables), " ", join('/', @tables), "\n" if $self->debug;
-    print "ignores: ", scalar(@ignores), " ", join('/', @ignores), "\n" if $self->debug;
+    $self->say_with_header(sprintf("tables: %d %s\n", scalar(@tables), join('/', @tables)));
+    $self->say_with_header(sprintf("ignores: %d %s\n", scalar(@ignores), join('/', @ignores)));
 
     my @options = qw(--skip-lock-tables);
     # Without any table names, mysqldump thinks that it should dump
     # everything. We need to add special arguments to handle this
     if ($nothing_to_dump) {
-        print "everything is excluded, nothing to dump !\n" if $self->debug;
+        $self->say_with_header("everything is excluded, nothing to dump !\n");
         push @options, qw(--no-create-info --no-data);
         @ignores = ();  # to clean-up the command-line
     }

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/Dummy.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/Dummy.pm
@@ -89,9 +89,9 @@ sub run {
 
     my $take_time = eval $self->param('take_time');
     if($take_time) {
-        print "Sleeping for '$take_time' seconds...\n";
+        $self->say_with_header("Sleeping for '$take_time' seconds...\n");
         usleep( $take_time*1000000 );
-        print "Done.\n";
+        $self->say_with_header("Done.\n");
     }
 }
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/JobFactory.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/JobFactory.pm
@@ -212,9 +212,7 @@ sub _get_rows_from_list {
 sub _get_rows_from_query {
     my ($self, $inputquery) = @_;
 
-    if($self->debug()) {
-        warn qq{inputquery = "$inputquery"\n};
-    }
+    $self->say_with_header(qq{inputquery = "$inputquery"\n});
     my @rows = ();
     my $sth = $self->data_dbc()->prepare($inputquery);
     $sth->execute();
@@ -240,9 +238,7 @@ sub _get_rows_from_query {
 sub _get_rows_from_open {
     my ($self, $input_file_or_command, $open_mode, $delimiter, $parse_header) = @_;
 
-    if($self->debug()) {
-        warn qq{input_file_or_command = "$input_file_or_command" [$open_mode]\n};
-    }
+    $self->say_with_header(qq{input_file_or_command = "$input_file_or_command" [$open_mode]\n});
     my @rows = ();
     open(my $fh, $open_mode, $input_file_or_command) or die "Could not open '$input_file_or_command' because: $!";
     while(my $line = <$fh>) {

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlCmd.pm
@@ -107,9 +107,7 @@ sub _exec_sql {
     my $counter = 0;
     foreach my $sql (@$sqls) {
 
-         if($self->debug()) {
-             warn qq{sql = "$sql"\n};
-         }
+        $self->say_with_header(qq{sql = "$sql"\n});
 
         $data_dbc->do( $sql ) or die "Could not run '$sql': ".$data_dbc->db_handle->errstr;
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlHealthcheck.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlHealthcheck.pm
@@ -150,15 +150,15 @@ sub _run_test {
         $query =~ s/$1//;
     }
 
-    print "Test description: $description\n";
-    print "Checking whether the number of rows $logical_test $reference_size\n";
+    $self->say_with_header( "Test description: $description\n" );
+    $self->say_with_header( "Checking whether the number of rows $logical_test $reference_size\n" );
 
     # This could benefit from 'switch' once we move to a more recent version of Perl
     my $maxrow = $reference_size;
     $maxrow++ if grep {$_ eq $logical_test} qw(= == > <= <> !=);
 
     $query .= " LIMIT $maxrow" unless $query =~ /LIMIT/i;
-    print "Query: $query\n";
+    $self->say_with_header( "Query: $query\n" );
 
     my $sth = $self->data_dbc()->prepare( $query,
                                     ($self->data_dbc->driver eq 'mysql') ? { 'mysql_use_result' => 1 } : undef );
@@ -170,7 +170,7 @@ sub _run_test {
     }
     $sth->finish;
 
-    print "$nrow rows returned".($nrow == $maxrow ? " (test aborted, there could be more rows)" : "")."\n";
+    $self->say_with_header( "$nrow rows returned".($nrow == $maxrow ? " (test aborted, there could be more rows)" : "")."\n" );
 
     # This could benefit from 'switch' once we move to a more recent version of Perl
     my $success = 0;
@@ -189,7 +189,7 @@ sub _run_test {
     } else {
         die "This should not happen. A logical test is not checked";
     }
-    warn $success ? "Success\n\n" : "Failure\n\n";
+    $self->say_with_header( $success ? "Success\n\n" : "Failure\n\n", 'important');
     return $success;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/Valley.pm
+++ b/modules/Bio/EnsEMBL/Hive/Valley.pm
@@ -256,7 +256,7 @@ sub cleanup_left_temp_directory {
     my $meadow = $self->available_meadow_hash->{$worker->meadow_type};
 
     if ($meadow->config_get('CleanupTempDirectoryKilledWorkers')) {
-        warn "GarbageCollector:\tCleaning-up /tmp\n";
+        print "GarbageCollector:\tCleaning-up /tmp\n";
         my $rc = $meadow->run_on_host($worker->meadow_host, $worker->meadow_user, ['rm', '-rf', $worker->temp_directory_name]);
         $worker->worker_say(sprintf("Error: could not clean %s's temp directory '%s': %s\n", $worker->meadow_host, $worker->temp_directory_name, $@)) if $rc;
     }

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -742,7 +742,7 @@ sub run_one_batch {
 
         my $job_completion_line = "Job $job_id : ". ($job->died_somewhere ? 'died' : 'complete' );
 
-        print STDERR "\n$job_completion_line\n" if($self->log_dir and ($self->debug or $job->died_somewhere));  # one copy goes to the job's STDERR
+        print "\n$job_completion_line\n" if($self->log_dir and ($self->debug or $job->died_somewhere));         # one copy goes to the job's STDERR
         $self->stop_job_output_redirection($job);                                                               # and then we switch back to worker's STDERR
         $self->worker_say( $job_completion_line );                                                              # one copy goes to the worker's STDERR
 

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -227,7 +227,7 @@ sub main {
     my $pipeline_name = $self->{'pipeline'}->hive_pipeline_name;
 
     if($pipeline_name) {
-        warn "Pipeline name: $pipeline_name\n";
+        print "Pipeline name: $pipeline_name\n";
     } else {
         print STDERR "+---------------------------------------------------------------------+\n";
         print STDERR "!                                                                     !\n";
@@ -253,7 +253,7 @@ sub main {
     $valley->config_set('SubmitWorkersMax', $submit_workers_max) if(defined $submit_workers_max);
 
     my $default_meadow = $valley->get_default_meadow();
-    warn "Default meadow: ".$default_meadow->signature."\n\n";
+    print "Default meadow: ".$default_meadow->signature."\n\n";
 
     $default_meadow->config_set('TotalRunningWorkersMax', $total_running_workers_max) if(defined $total_running_workers_max);
     $default_meadow->config_set('SubmissionOptions', $submission_options) if(defined $submission_options);
@@ -589,7 +589,7 @@ sub run_autonomously {
                         $meadow_process_ids = $this_meadow->submit_workers_return_meadow_pids($specific_worker_cmd, $this_meadow_rc_worker_count, $self->{'beekeeper_id'}.'_'.$iteration, $rc_name, $submission_cmd_args || '', $submit_log_subdir);
                     }
 
-                    warn "Submitted the following process_ids to ".$this_meadow->signature.": ".join(', ', @$meadow_process_ids)."\n";
+                    print "Submitted the following process_ids to ".$this_meadow->signature.": ".join(', ', @$meadow_process_ids)."\n";
 
                     my $resource_class  = $pipeline->collection_of('ResourceClass')->find_one_by('name', $rc_name);
                     my $meadow_name     = $this_meadow->cached_name;

--- a/t/02.api/latest_schema_patch.t
+++ b/t/02.api/latest_schema_patch.t
@@ -110,8 +110,8 @@ foreach my $driver (qw(mysql pgsql sqlite)) {
         is_deeply($schema1, $schema2, 'Both schemas are identical');
 
         # For debugging
-        #warn $url1;
-        #warn $url2;
+        #note($url1);
+        #note($url2);
         run_sql_on_db($url1, 'DROP DATABASE');
         run_sql_on_db($url2, 'DROP DATABASE');
     };

--- a/t/04.meadow/meadow-longmult.mt
+++ b/t/04.meadow/meadow-longmult.mt
@@ -34,7 +34,7 @@ my @pipeline_cfgs = qw(LongMult_conf);
 
 foreach my $long_mult_version ( @pipeline_cfgs ) {
 
-    warn "\nInitializing the $long_mult_version pipeline ...\n\n";
+    note("\nInitializing the $long_mult_version pipeline ...\n\n");
 
     foreach my $pipeline_url (@pipeline_urls) {
             # override the 'take_time' PipelineWideParameter in the loaded HivePipeline object to make the internal test Worker run quicker:

--- a/t/10.pipeconfig/gc_dataflow.t
+++ b/t/10.pipeconfig/gc_dataflow.t
@@ -52,7 +52,7 @@ until ($process_id) {
 ok($process_id, 'Found a process_id');
 
 # Kill the process
-warn "got process_id $process_id";
+note("got process_id $process_id");
 system('kill', '-SIGKILL', $process_id);
 sleep 10; # must be more than MaxLimboSeconds for beekeeper to actual rip the worker
 

--- a/t/10.pipeconfig/gcpct.t
+++ b/t/10.pipeconfig/gcpct.t
@@ -45,7 +45,7 @@ my $sleep_minutes = $ENV{'EHIVE_GCPCT_SLEEP'} || 0.02;
 
 foreach my $gcpct_version ( @pipeline_cfgs ) {
 
-warn "\nInitializing the $gcpct_version pipeline ...\n\n";
+        note("\nInitializing the $gcpct_version pipeline ...\n\n");
 
         my $pipeline_url = get_test_url_or_die();
             # override the 'take_time' PipelineWideParameter in the loaded HivePipeline object to make the internal test Worker run quicker:

--- a/t/10.pipeconfig/guest_language.t
+++ b/t/10.pipeconfig/guest_language.t
@@ -50,7 +50,7 @@ foreach my $long_mult_version ( @pipeline_cfgs ) {
     SKIP: {
         skip "python3 not installed", 2 if($long_mult_version =~ /_pyconf/ && !`python3 --version 2>/dev/null`);
 
-    warn "\nInitializing the $long_mult_version pipeline ...\n\n";
+        note("\nInitializing the $long_mult_version pipeline ...\n\n");
 
             # override the 'take_time' PipelineWideParameter in the loaded HivePipeline object to make the internal test Worker run quicker:
         init_pipeline(

--- a/t/10.pipeconfig/kmer.t
+++ b/t/10.pipeconfig/kmer.t
@@ -75,7 +75,7 @@ my $pipeline_url = get_test_url_or_die();
 
     foreach my $kmer_pipeline_mode ( @kmer_pipeline_modes ) {
       
-      warn "\nInitializing the $kmer_version $kmer_pipeline_mode sequence pipeline into $pipeline_url ...\n\n";
+      note("\nInitializing the $kmer_version $kmer_pipeline_mode sequence pipeline into $pipeline_url ...\n\n");
       
       init_pipeline($kmer_version, $pipeline_url, $kmer_param_configs->{$kmer_pipeline_mode});
       

--- a/t/10.pipeconfig/longmult.t
+++ b/t/10.pipeconfig/longmult.t
@@ -47,7 +47,7 @@ foreach my $long_mult_version ( @pipeline_cfgs ) {
     # Exclude the guest-language config files
     next unless $long_mult_version =~ /_conf/;
 
-    warn "\nInitializing the $long_mult_version pipeline ...\n\n";
+    note("\nInitializing the $long_mult_version pipeline ...\n\n");
 
     foreach my $pipeline_url (@pipeline_urls) {
             # override the 'take_time' PipelineWideParameter in the loaded HivePipeline object to make the internal test Worker run quicker:


### PR DESCRIPTION
As I was writing the documentation of the Runnable API, I realized that `Process::say_with_header` was printing messages to either stdout or stderr, depending whether the job is standalone or not. I wanted to harmonize that, and ended up fixing up several other modules. My guidelines were:
 - Use `say_with_header` in Runnables
 - Print to stdout (no STDERR/warn) when the message is just an information (I kept all the "real" warnings as `warn`)