### PR TITLE
Improvements to NotifyByEmail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
 
 
 install:
-    - cpanm -v --installdeps --notest .
+    - cpanm -v --installdeps --with-recommends --notest .
     - cpanm -n Devel::Cover::Report::Coveralls
     - cpanm -n Devel::Cover::Report::Codecov
 

--- a/cpanfile
+++ b/cpanfile
@@ -24,4 +24,5 @@ recommends 'Getopt::ArgvFile';
 recommends 'BSD::Resource';
 recommends 'Chart::Gnuplot';
 recommends 'GraphViz';
+recommends 'Email::Stuffer';
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
@@ -128,7 +128,7 @@ sub format_table {
 
     foreach (@$results) {
         for (my $i=0; $i < scalar(@$_); $i++) {
-            my $len = length($$_[$i]) + 2;
+            my $len = length($$_[$i] // 'N/A') + 2;
             $lengths[$i] = $len if $len > $lengths[$i];
         }
     }
@@ -146,7 +146,7 @@ sub format_table {
 
     foreach (@$results) {
         for (my $i=0; $i < scalar(@lengths); $i++) {
-            my $value = $$_[$i];
+            my $value = $$_[$i] // 'N/A';
             my $padding = $lengths[$i] - length($value) - 2;
             $table .= '| '.$value.(' ' x $padding).' ';
         }

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
@@ -111,4 +111,51 @@ sub run {
 sub write_output {
 }
 
+
+
+######################
+## Internal methods ##
+######################
+
+# Present data in a nice table, like what mySQL does.
+sub format_table {
+    my ($self, $title, $columns, $results) = @_;
+
+    my @lengths;
+    foreach (@$columns) {
+        push @lengths, length($_) + 2;
+    }
+
+    foreach (@$results) {
+        for (my $i=0; $i < scalar(@$_); $i++) {
+            my $len = length($$_[$i]) + 2;
+            $lengths[$i] = $len if $len > $lengths[$i];
+        }
+    }
+
+    my $table = "$title\n";
+    $table .= '+'.join('+', map {'-' x $_ } @lengths).'+'."\n";
+
+    for (my $i=0; $i < scalar(@lengths); $i++) {
+        my $column = $$columns[$i];
+        my $padding = $lengths[$i] - length($column) - 2;
+        $table .= '| '.$column.(' ' x $padding).' ';
+    }
+
+    $table .= '|'."\n".'+'.join('+', map {'-' x $_ } @lengths).'+'."\n";
+
+    foreach (@$results) {
+        for (my $i=0; $i < scalar(@lengths); $i++) {
+            my $value = $$_[$i];
+            my $padding = $lengths[$i] - length($value) - 2;
+            $table .= '| '.$value.(' ' x $padding).' ';
+        }
+        $table .= '|'."\n"
+    }
+
+    $table .= '+'.join('+', map {'-' x $_ } @lengths).'+'."\n";
+
+    return $table;
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/NotifyByEmail.pm
@@ -6,27 +6,34 @@
 
 =head1 SYNOPSIS
 
-    This is a RunnableDB module that implements Bio::EnsEMBL::Hive::Process interface
-    and is ran by Workers during the execution of eHive pipelines.
-    It is not generally supposed to be instantiated and used outside of this framework.
+This is a RunnableDB module that implements Bio::EnsEMBL::Hive::Process interface
+and is ran by Workers during the execution of eHive pipelines.
+It is not generally supposed to be instantiated and used outside of this framework.
 
-    Please refer to Bio::EnsEMBL::Hive::Process documentation to understand the basics of the RunnableDB interface.
+Please refer to Bio::EnsEMBL::Hive::Process documentation to understand the basics of the RunnableDB interface.
 
-    Please refer to Bio::EnsEMBL::Hive::PipeConfig::* pipeline configuration files to understand how to configure pipelines.
+Please refer to Bio::EnsEMBL::Hive::PipeConfig::* pipeline configuration files to understand how to configure pipelines.
 
 =head1 DESCRIPTION
 
-    This RunnableDB module will send you a short notification email message per each job.
-    You can either dataflow into it, or simply create standalone jobs.
+This RunnableDB module will send you a short notification email message per
+each job.  You can either dataflow into it, or simply create standalone
+jobs.
 
-    The main body of the email is expected in the "text" parameter. If the "is_html" parameter is set, the body
-    is expected to be in HTML.
+The main body of the email is expected in the "text" parameter. If the
+"is_html" parameter is set, the body is expected to be in HTML.
 
-    Attachments such as diagrams, images, PDFs have to be listed in the 'attachments' parameter.
+Attachments such as diagrams, images, PDFs have to be listed in the
+'attachments' parameter.
 
-    Note: this module depends heavily on the implementation of your compute farm.
-    Sendmail may be unsupported, or supported differently.
-    Please make sure it works as intended before using this module in complex pipelines.
+C<format_table> provides a simple method to stringify a table of data. If
+you need more options to control the separators, the alignment, etc, have a
+look at the very comprehensive L<Text::Table>.
+
+Note: this module uses L<Email::Sender> to send the email, which by default
+uses C<sendmail> but has other backends configured. As such, it depends
+heavily on the implementation of your compute farm. Please make sure it
+works as intended before using this module in complex pipelines.
 
 =head1 LICENSE
 
@@ -136,6 +143,20 @@ sub write_output {
 ######################
 
 # Present data in a nice table, like what mySQL does.
+
+
+=head2 format_table
+
+The same type of table could be generated with L<Text::Table>:
+
+  my $first_column_name = shift @$columns;
+  my $tb = Text::Table->new(\'| ', $first_column_name, (map { +(\' | ', $_) } @$columns), \' |',);
+  $tb->load(@$results);
+  my $rule = $tb->rule('-', '+');
+  return $title . "\n" . $rule . $tb->title() . $rule .  $tb->body() . $rule;
+
+=cut
+
 sub format_table {
     my ($self, $title, $columns, $results) = @_;
 

--- a/t/05.runnabledb/email.t
+++ b/t/05.runnabledb/email.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2017] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Cwd            ();
+use File::Basename ();
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+use Test::More;
+
+BEGIN {
+    ## at least it compiles
+    use_ok( 'Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail' );
+}
+
+subtest 'format_table' => sub {
+    my $title = 'Table title';
+    my $columns = ['a', 'b'];
+    my $data = [ ['x', 'y'], ['', '0'], [undef, '12345678'] ];
+    my $expected_table = <<'END';
+Table title
++-----+----------+
+| a   | b        |
++-----+----------+
+| x   | y        |
+|     | 0        |
+| N/A | 12345678 |
++-----+----------+
+END
+    my $got_table = Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail->format_table($title, $columns, $data);
+    is($got_table, $expected_table, 'Table with empty strings and missing values');
+};
+
+
+done_testing();


### PR DESCRIPTION
Addresses two comments that are only 2 years old ^^:
 - https://genomes-ebi.slack.com/archives/C0HTNH2GG/p1456929232000231
 - https://genomes-ebi.slack.com/archives/C0HTNH2GG/p1456929816000233

The NotifyByEmail Runnable was really simplistic. Switching to [Email::Stuffer](http://search.cpan.org/~rjbs/Email-Stuffer-0.014/lib/Email/Stuffer.pm) allows adding attachments very easily, and gives a better support of multi-part emails, e.g. with HTML content, etc. Note for @james-monkeyshines : Email::Stuffer is in fact just a wrapper around Email::MIME, which you are now using in EGPipeline/RNAFeatures/EmailRNAReport.pm instead of MIME::Lite, so I expect it to work in your pipelines.

MIME::Lite is not maintained any more (http://search.cpan.org/~rjbs/MIME-Lite-3.030/lib/MIME/Lite.pm) but since it was based on Email::Sender, like Email::Stuffer is, I believe collaborators account should be able to send emails too.
