### PR TITLE
Show a nice error message when connecting to the database with a read-only user

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -376,8 +376,12 @@ sub run_in_transaction {
 sub has_write_access {
     my $self = shift;
     if ($self->driver eq 'mysql') {
-        my $a =  $self->db_handle->selectrow_arrayref('SELECT Insert_priv, Update_priv, Delete_priv FROM mysql.user WHERE user = ?', undef, $self->username);
-        return !scalar(grep {$_ eq 'N'} @$a);
+        my $user_entries =  $self->db_handle->selectall_arrayref('SELECT Insert_priv, Update_priv, Delete_priv FROM mysql.user WHERE user = ?', undef, $self->username);
+        my $has_write_access_from_some_host = 0;
+        foreach my $entry (@$user_entries) {
+            $has_write_access_from_some_host ||= !scalar(grep {$_ eq 'N'} @$entry);
+        }
+        return $has_write_access_from_some_host;
     } else {
         # TODO: implement this for other drivers
         return 1;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
@@ -55,6 +55,7 @@ sub init_pipeline {
 
     my $hive_dba = $pipeline->hive_dba()
         or die "HivePipeline could not be created for ".$pipeconfig_object->pipeline_url();
+    $hive_dba->dbc->requires_write_access();
 
     print "> Parsing the PipeConfig file and adding objects (this may take a while).\n\n";
     $pipeconfig_object->add_objects_from_config( $pipeline );

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -261,7 +261,6 @@ sub main {
         undef $discard_ready_jobs;
         undef $kill_worker_id;
         undef $sync;
-        $self->{'max_loops'} = 0;
         $self->{'read_only'} = 1;
     }
 
@@ -425,17 +424,6 @@ sub main {
         $self->{'beekeeper'}->set_cause_of_death('LOOP_LIMIT') unless $self->{'read_only'};
     }
 
-    if ($self->{'read_only'}) {
-        $has_error = 1;
-        print STDERR "\n";
-        print STDERR "*" x 70, "\n";
-        print STDERR "* beekeeper.pl is running in read-only mode, i.e. it only\n";
-        print STDERR "* prints the current status of the pipeline.\n";
-        print STDERR "*\n";
-        print STDERR "*" x 70, "\n";
-        print STDERR "\n";
-    }
-
     exit($has_error);
 }
 
@@ -518,7 +506,7 @@ sub run_autonomously {
 
     my $hive_dba    = $pipeline->hive_dba;
     my $queen       = $hive_dba->get_Queen;
-    my $meadow_user = $self->{'beekeeper'}->meadow_user;
+    my $meadow_user = $self->{'beekeeper'} && $self->{'beekeeper'}->meadow_user;
 
     my $pathless_resourceless_worker_cmd = generate_worker_cmd($self, $analyses_pattern, $run_job_id, $force);
 
@@ -529,7 +517,7 @@ sub run_autonomously {
 
         print("\nBeekeeper : loop #$iteration ======================================================\n");
 
-        $queen->check_for_dead_workers($valley, 0);
+        $queen->check_for_dead_workers($valley, 0) unless $self->{'read_only'};
 
         # this section is where the beekeeper decides whether or not to stop looping
         $reasons_to_exit = $queen->print_status_and_return_reasons_to_exit( $list_of_analyses, $self->{'debug'});
@@ -579,8 +567,8 @@ sub run_autonomously {
 
         $hive_dba->get_RoleAdaptor->print_active_role_counts;
 
-        my $workers_to_submit_by_meadow_type_rc_name
-            = Bio::EnsEMBL::Hive::Scheduler::schedule_workers_resync_if_necessary($queen, $valley, $list_of_analyses);
+        my $workers_to_submit_by_meadow_type_rc_name = $self->{'read_only'} ? {} :
+              Bio::EnsEMBL::Hive::Scheduler::schedule_workers_resync_if_necessary($queen, $valley, $list_of_analyses);
 
         if( keys %$workers_to_submit_by_meadow_type_rc_name ) {
 
@@ -650,6 +638,16 @@ sub run_autonomously {
                     $queen->store( \@pre_allocated_workers );
                 }
             }
+
+        } elsif ($self->{'read_only'}) {
+            print STDERR "\n";
+            print STDERR "*" x 70, "\n";
+            print STDERR "* beekeeper.pl is running in read-only mode, i.e. it only\n";
+            print STDERR "* prints the current status of the pipeline.\n";
+            print STDERR "*\n";
+            print STDERR "*" x 70, "\n";
+            print STDERR "\n";
+
         } else {
             print "\nBeekeeper : not submitting any workers this iteration\n";
             $self->{'logmessage_adaptor'}->store_beekeeper_message($self->{'beekeeper_id'},
@@ -662,6 +660,7 @@ sub run_autonomously {
                 $hive_dba->dbc->disconnect_if_idle;
                 printf("Beekeeper : going to sleep for %.2f minute(s). Expect next iteration at %s\n", $self->{'sleep_minutes'}, scalar localtime(time+$self->{'sleep_minutes'}*60));
                 sleep($self->{'sleep_minutes'}*60);
+                last if $self->{'read_only'};
                 # this is a good time to check up on other beekeepers as well:
                 $self->{'beekeeper'}->adaptor->bury_other_beekeepers($self->{'beekeeper'});
                 if ($self->{'beekeeper'}->check_if_blocked()) {
@@ -723,13 +722,13 @@ sub run_autonomously {
     $self->{'logmessage_adaptor'}->store_beekeeper_message($self->{'beekeeper_id'},
         "stopped looping because of $stringified_reasons",
         $cause_of_death_is_error ? 'PIPELINE_ERROR' : 'INFO',
-        $beekeeper_cause_of_death);
+        $beekeeper_cause_of_death) unless $self->{'read_only'};
 
     if ($reasons_to_exit and $ENV{EHIVE_SLACK_WEBHOOK}) {
         send_beekeeper_message_to_slack($ENV{EHIVE_SLACK_WEBHOOK}, $self->{'pipeline'}, $cause_of_death_is_error, 1, $stringified_reasons, $loop_until);
     }
 
-    $self->{'beekeeper'}->set_cause_of_death($beekeeper_cause_of_death);
+    $self->{'beekeeper'}->set_cause_of_death($beekeeper_cause_of_death) unless $self->{'read_only'};
     printf("Beekeeper: dbc %d disconnect cycles\n", $hive_dba->dbc->disconnect_count);
     return $cause_of_death_is_error;
 }

--- a/scripts/hoover_pipeline.pl
+++ b/scripts/hoover_pipeline.pl
@@ -56,6 +56,7 @@ sub main {
                 -reg_alias                      => $reg_alias,
                 -no_sql_schema_version_check    => $nosqlvc,
         );
+        $hive_dba->dbc->requires_write_access();
     } else {
         die "\nERROR: Connection parameters (url or reg_conf+reg_alias) need to be specified\n";
     }

--- a/scripts/load_resource_usage.pl
+++ b/scripts/load_resource_usage.pl
@@ -59,6 +59,7 @@ sub main {
                 -reg_alias                      => $reg_alias,
                 -no_sql_schema_version_check    => $nosqlvc,
         );
+        $hive_dba->dbc->requires_write_access();
     } else {
         die "\nERROR: Connection parameters (url or reg_conf+reg_alias) need to be specified\n";
     }

--- a/scripts/runWorker.pl
+++ b/scripts/runWorker.pl
@@ -104,6 +104,7 @@ sub main {
             -reg_alias                      => $reg_alias,
             -no_sql_schema_version_check    => $nosqlvc,
         );
+        $pipeline->hive_dba()->dbc->requires_write_access();
 
     } else {
         die "\nERROR: Connection parameters (url or reg_conf+reg_alias) need to be specified\n";

--- a/scripts/seed_pipeline.pl
+++ b/scripts/seed_pipeline.pl
@@ -86,6 +86,7 @@ sub main {
                 -reg_alias                      => $reg_alias,
                 -no_sql_schema_version_check    => $nosqlvc,
         );
+        $pipeline->hive_dba()->dbc->requires_write_access();
     } else {
         die "\nERROR: Connection parameters (url or reg_conf+reg_alias) need to be specified\n";
     }

--- a/scripts/tweak_pipeline.pl
+++ b/scripts/tweak_pipeline.pl
@@ -69,6 +69,7 @@ sub main {
     if(@$tweaks) {
         my $need_write = $pipeline->apply_tweaks( $tweaks );
         if ($need_write) {
+            $pipeline->hive_dba()->dbc->requires_write_access();
             $pipeline->save_collections();
         }
     }


### PR DESCRIPTION
beekeeper.pl, like other scripts needs a read+write connection to the database.
As I often (by mistake) use `ensro`, I'm a bit tired of seeing this stack trace:
```
mattxps:~ $ beekeeper.pl -url 'mysql://ensro@localhost/matthieu_test_db_master'
Pipeline name: long_mult
Default meadow: LOCAL/mattxps

DBD::mysql::st execute failed: INSERT command denied to user 'ensro'@'localhost' for table 'beekeeper' at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm line 119.
DBD::mysql::st execute failed: INSERT command denied to user 'ensro'@'localhost' for table 'beekeeper' at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm line 119.
 at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm line 145.
        Bio::EnsEMBL::Hive::DBSQL::StatementHandle::__ANON__('Bio::EnsEMBL::Hive::DBSQL::StatementHandle=HASH(0x3a61b18)', 0, 'ANALYSIS_FAILURE', 'mattxps', 'LOCAL/mattxps', 'matthieu', '-url mysql://ensro@localhost/matthieu_test_db_master', 11026, 1, ...) called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm line 528
        Bio::EnsEMBL::Hive::DBSQL::BaseAdaptor::class_specific_execute('Bio::EnsEMBL::Hive::DBSQL::BeekeeperAdaptor=HASH(0x3a4a680)', 'Bio::EnsEMBL::Hive::Beekeeper=HASH(0x3a4a6e0)', 'Bio::EnsEMBL::Hive::DBSQL::StatementHandle=HASH(0x3a61b18)', 'ARRAY(0x3a4e8c0)') called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm line 578
        Bio::EnsEMBL::Hive::DBSQL::BaseAdaptor::store('Bio::EnsEMBL::Hive::DBSQL::BeekeeperAdaptor=HASH(0x3a4a680)', 'Bio::EnsEMBL::Hive::Beekeeper=HASH(0x3a4a6e0)') called at /home/matthieu/workspace/src/hive/master/scripts/beekeeper.pl line 471
        main::register_beekeeper('Bio::EnsEMBL::Hive::Valley=HASH(0x35907a8)', 'HASH(0x23bfcb8)') called at /home/matthieu/workspace/src/hive/master/scripts/beekeeper.pl line 285
        main::main() called at /home/matthieu/workspace/src/hive/master/scripts/beekeeper.pl line 32
```
And I though I could make the error message a bit nicer.

In this commit I introduce `has_write_access` in DBConnection, which returns a boolean, and `requires_write_access`, which dies or does nothing. Each script that needs to write to the database now calls `requires_write_access`. There is one exception: beekeeper, as it still can print the status of the pipeline, a warning message about the database user and exit with the error code 1. Do you think beekeeper should just die like the other scripts ? Here is how it looks like with my changes

```
mattxps:~ $ runWorker.pl -url 'mysql://ensro@localhost/matthieu_test_db_master'
It appears that ensro doesn't have INSERT/UPDATE/DELETE privileges on this database (matthieu_test_db_master). Please check the credentials
mattxps:~ $ beekeeper.pl -url 'mysql://ensro@localhost/matthieu_test_db_master' -debug 9
Pipeline name: long_mult

**********************************************************************
* It appears that ensro doesn't have INSERT/UPDATE/DELETE privileges
* on this database (matthieu_test_db_master). Please check the credentials
*
**********************************************************************

Default meadow: LOCAL/mattxps

take_b_apart (  1)       READY, jobs(                       2r ), avg:  0.0 ms , workers(Running:0, Est.Required:1)   h.cap:-  a.cap:1  (sync'd 2789 sec ago)
part_multiply(  2)       EMPTY, jobs(                       =0 ), avg:  0.0 ms , workers(Running:0, Est.Required:0)   h.cap:-  a.cap:1  (sync'd 0 sec ago)
add_together (  3)       EMPTY, jobs(                       =0 ), avg:  0.0 ms , workers(Running:0, Est.Required:0)   h.cap:-  a.cap:1  (sync'd 0 sec ago)

total over 3 analyses :   0.00% complete (< 0.00 CPU_hrs) (2 to_do + 0 done + 0 failed + 0 excluded = 2 total)

===== Stats of active Roles as recorded in the pipeline database: ======
         ======= TOTAL ======= : 0 active Roles

**********************************************************************
* beekeeper.pl is running in read-only mode, i.e. it only
* prints the current status of the pipeline.
*
**********************************************************************
```

My other question is about the implementation of `has_write_access`. I couldn't find a clean way of checking the permissions of the current user. It looks like in theory, the permissions of a given user could vary per host it's connecting from, per database and  per table ?
I didn't feel like parsing the output of `SHOW GRANTS`, e.g.
```
| GRANT SELECT, RELOAD, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, SHOW VIEW ON *.* TO 'ensro'@'%' |                                                                                                                                                                 
| GRANT SELECT ON `%\_%`.* TO 'ensro'@'%'                                                                     |                                                                                                                                                                 
```
and I reckon my implementation is simplistic. Is there a real risk that the user has no write permissions in general, but has write permissions enabled at the database level ?
I think it's fine not to capture all the cases where there is no write permissions (as DBI would just fail anyway when trying to write stuff) but it'd be bad preventing accessing the database if there is no real reason.
Also, I haven't searched how to check those in PostreSQL