### PR TITLE
Print a nicer error message if $self->data_dbc cannot be evaluated

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -427,6 +427,13 @@ sub data_dbc {
     my $given_ref = ref( $given_db_conn );
     my $given_signature = ($given_ref eq 'ARRAY' or $given_ref eq 'HASH') ? stringify ( $given_db_conn ) : "$given_db_conn";
 
+    if (!$self->param_is_defined('db_conn') and !$self->db and !$self->dbc) {
+        # go_figure_dbc won't be able to create a DBConnection, so let's
+        # just print a nicer error message
+        $self->input_job->transient_error(0);
+        throw('In standaloneJob mode, $self->data_dbc requires the -db_conn parameter to be defined on the command-line');
+    }
+
     if( !$self->{'_cached_db_signature'} or ($self->{'_cached_db_signature'} ne $given_signature) ) {
         $self->{'_cached_db_signature'} = $given_signature;
         $self->{'_cached_data_dbc'} = go_figure_dbc( $given_db_conn );


### PR DESCRIPTION
eHive provides `$self->data_dbc` to Runnables, which defaults to the current (eHive) database but can be overridden with the `db_conn` parameter. In standaloneJob mode, since there is no database, `db_conn` is (meant to be) the only way of setting this, and this commit prints a clearer error message (with the stack trace) when the parameter is missing
```
Running 'Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck' with input_id='{"query" => "SELECT * FROM meta"}' :
Standalone worker 8333 : WORKER_ERROR : In standaloneJob mode, $self->data_dbc requires the -db_conn parameter to be defined on the command-line at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Process.pm line 613.
        Bio::EnsEMBL::Hive::Process::throw() called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Process.pm line 434
        Bio::EnsEMBL::Hive::Process::data_dbc('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck=HASH(0x2abf270)') called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlHealthcheck.pm line 163
        Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck::_run_test('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck=HASH(0x2abf270)', 'HASH(0x2e65990)') called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlHealthcheck.pm line 120
        Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck::run('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck=HASH(0x2abf270)') called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Process.pm line 150
        eval {...} called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Process.pm line 132
        Bio::EnsEMBL::Hive::Process::life_cycle('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck=HASH(0x2abf270)') called at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Scripts/StandaloneJob.pm line 83
        Bio::EnsEMBL::Hive::Scripts::StandaloneJob::standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck', '{"query" => "SELECT * FROM meta"}', 'HASH(0x2a64e60)', undef, undef) called at /home/matthieu/workspace/src/hive/master/scripts/standaloneJob.pl line 119
        main::main() called at /home/matthieu/workspace/src/hive/master/scripts/standaloneJob.pl line 24
```
instead of
```
Running 'Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck' with input_id='{"query" => "SELECT * FROM meta"}' :
Standalone worker 8444 : WORKER_ERROR : Sorry, could not figure out how to make a DBConnection object out of 'Bio::EnsEMBL::Hive::RunnableDB::SqlHealthcheck=HASH(0x36627c0)' at /home/matthieu/workspace/src/hive/master/modules/Bio/EnsEMBL/Hive/Utils.pm line 343.
```

It's a simple change, but do you think the message makes it clear what the issue is ? I feel like the stack trace clutters the output. Should I use `die` instead of `throw` ?
