### PR TITLE
Performance improvements to init_pipeline.pl/generate_graph.pl

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
@@ -45,7 +45,6 @@ use Bio::EnsEMBL::Hive::HivePipeline;
 use Bio::EnsEMBL::Hive::DBSQL::DBConnection;
 use Bio::EnsEMBL::Hive::DBSQL::SqlSchemaAdaptor;
 use Bio::EnsEMBL::Hive::Utils ('throw');
-use Bio::EnsEMBL::Hive::Utils::Collection;
 
 use Bio::EnsEMBL::Hive::MetaParameters;
 use Bio::EnsEMBL::Hive::PipelineWideParameters;

--- a/modules/Bio/EnsEMBL/Hive/DataflowRule.pm
+++ b/modules/Bio/EnsEMBL/Hive/DataflowRule.pm
@@ -112,18 +112,32 @@ sub get_my_targets_grouped_by_condition {
 }
 
 
-sub unitargets {
-    my $self    = shift @_;
-    my $targets = shift @_ || $self->get_my_targets;
-
-    if(ref($targets)) {
-        my $unitargets = join( ';', map { ($_->on_condition//'').':'.($_->input_id_template//'').':'.$_->to_analysis_url }
+sub _compute_unitargets {
+    my $targets = shift;
+    return join( ';', map { ($_->on_condition//'').':'.($_->input_id_template//'').':'.$_->to_analysis_url }
                                         sort { ($a->on_condition//'') cmp ($b->on_condition//'')
                                             or ($a->input_id_template//'') cmp ($b->input_id_template//'') }
                                             @$targets);
+}
 
-        return $unitargets;
+# NOTE: By caching the "unitargets" value, we assume that the list of
+# targets will *not* change once the object is loaded. This holds true at
+# the moment, but we need to be careful it remains the case in the future,
+# otherwise the bits that change the targets would have to invalidate the
+# cached value
+sub unitargets {
+    my $self    = shift @_;
+
+    if (@_) {
+        $self->{'_cached_unitargets'} = shift @_;
     }
+
+    unless ($self->{'_cached_unitargets'}) {
+        my $targets = $self->get_my_targets;
+        $self->{'_cached_unitargets'} = _compute_unitargets( $targets );
+    }
+
+    return $self->{'_cached_unitargets'};
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -242,7 +242,7 @@ sub add_new_or_update {
         @unikey_pairs{ @$unikey_keys} = delete @other_pairs{ @$unikey_keys };
 
         if( $object = $coll->find_one_by( %unikey_pairs ) ) {
-            my $found_display = UNIVERSAL::can($object, 'toString') ? $object->toString : stringify($object);
+            my $found_display = $verbose && (UNIVERSAL::can($object, 'toString') ? $object->toString : stringify($object));
             if(keys %other_pairs) {
                 print "Updating $found_display with (".stringify(\%other_pairs).")\n" if $verbose;
                 if( ref($object) eq 'HASH' ) {
@@ -258,7 +258,7 @@ sub add_new_or_update {
         } elsif( my $dark_coll = $coll->dark_collection) {
             if( my $shadow_object = $dark_coll->find_one_by( %unikey_pairs ) ) {
                 $dark_coll->forget( $shadow_object );
-                my $found_display = UNIVERSAL::can($shadow_object, 'toString') ? $shadow_object->toString : stringify($shadow_object);
+                my $found_display = $verbose && (UNIVERSAL::can($shadow_object, 'toString') ? $shadow_object->toString : stringify($shadow_object));
                 print "Undeleting $found_display\n" if $verbose;
             }
         }
@@ -274,7 +274,7 @@ sub add_new_or_update {
 
         $object->hive_pipeline($self) if UNIVERSAL::can($object, 'hive_pipeline');
 
-        my $found_display = UNIVERSAL::can($object, 'toString') ? $object->toString : 'naked entry '.stringify($object);
+        my $found_display = $verbose && (UNIVERSAL::can($object, 'toString') ? $object->toString : 'naked entry '.stringify($object));
         print "Created a new $found_display\n" if $verbose;
     }
 

--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
@@ -68,7 +68,6 @@ use Scalar::Util qw(looks_like_number);
 
 use Bio::EnsEMBL::Hive;
 use Bio::EnsEMBL::Hive::Utils ('stringify', 'join_command_args', 'whoami');
-use Bio::EnsEMBL::Hive::Utils::Collection;
 use Bio::EnsEMBL::Hive::Utils::PCL;
 use Bio::EnsEMBL::Hive::Utils::URL;
 use Bio::EnsEMBL::Hive::DBSQL::SqlSchemaAdaptor;

--- a/modules/Bio/EnsEMBL/Hive/Storable.pm
+++ b/modules/Bio/EnsEMBL/Hive/Storable.pm
@@ -165,6 +165,7 @@ sub AUTOLOAD {
                 my $collection = $self->hive_pipeline && $self->hive_pipeline->collection_of($AdaptorType);
 
                 if( $collection and $self->{$foo_obj_method_name} = $collection->find_one_by('dbID', $foo_object_id) ) { # careful: $AdaptorType may not be unique (aliases)
+                    weaken($self->{$foo_obj_method_name});
 #                    warn "Lazy-loading object from $AdaptorType collection\n";
                 } elsif(my $adaptor = $self->adaptor) {
 #                    warn "Lazy-loading object from $AdaptorType adaptor\n";

--- a/modules/Bio/EnsEMBL/Hive/Utils/PCL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/PCL.pm
@@ -192,7 +192,7 @@ sub parse_flow_into {
                 'from_analysis'             => $from_analysis,
                 'branch_code'               => $branch_name_or_code,
                 'funnel_dataflow_rule'      => $funnel_dataflow_rule,
-                'unitargets'                => Bio::EnsEMBL::Hive::DataflowRule->unitargets($suspended_targets),
+                'unitargets'                => Bio::EnsEMBL::Hive::DataflowRule::_compute_unitargets($suspended_targets),
 #                'unitargets'                => $suspended_targets,
             );
 

--- a/modules/Bio/EnsEMBL/Hive/Utils/PCL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/PCL.pm
@@ -151,6 +151,7 @@ sub parse_flow_into {
             my $this_cond_group_marker = shift @$cond_group;
             die "Expecting $cond_group_marker, got $this_cond_group_marker" unless($this_cond_group_marker eq $cond_group_marker);
 
+            my $suspended_targets = [];
             while(@$cond_group) {
                 my $on_condition    = shift @$cond_group;
                 my $heirs           = shift @$cond_group;
@@ -181,12 +182,11 @@ sub parse_flow_into {
                             'extend_param_stack'        => $extend_param_stack,
                             'to_analysis_url'           => $heir_url,
                         );
+                        push @$suspended_targets, $df_target;
 
                     } # /for all templates
                 } # /for all heirs
             } # /for each condition and heir
-
-            my $suspended_targets = $pipeline->collection_of('DataflowTarget')->find_all_by( 'source_dataflow_rule', undef );
 
             my ($df_rule, $df_rule_is_new) = $pipeline->add_new_or_update( 'DataflowRule', $verbose,  # NB: add_new_or_update returns a list
                 'from_analysis'             => $from_analysis,


### PR DESCRIPTION
My test is Compara's Protein-Tree pipeline. With the proposed changes, loading the PipeConfig file (`$pipeconfig_object->add_objects_from_config($pipeline)`) now takes 0.7 seconds instead of 16 seconds.

The main improvements come from:
 - storing new subs in AUTOLOAD: 16 seconds -> 4 seconds
 - caching `DataflowRule::unitargets`: 4 seconds -> 0.7 seconds

There are other minor improvements:
 - only stringifying the objects in verbose mode
 - keep the list of Dataflow targets locally instead of searching them in the collection
