### PR TITLE
List the job statuses an their purpose only once

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisJobAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisJobAdaptor.pm
@@ -55,7 +55,7 @@ use base ('Bio::EnsEMBL::Hive::DBSQL::ObjectAdaptor');
 
 # This variable must be kept up-to-date ! It is used in a number of queries.
 # CLAIMED is missing on purpose because not all the queries actually need it.
-my $ALL_STATUSES_OF_RUNNING_JOBS = q{'PRE_CLEANUP','FETCH_INPUT','RUN','WRITE_OUTPUT','POST_HEALTHCHECK','POST_CLEANUP'};
+our $ALL_STATUSES_OF_RUNNING_JOBS = q{'PRE_CLEANUP','FETCH_INPUT','RUN','WRITE_OUTPUT','POST_HEALTHCHECK','POST_CLEANUP'};
 
 
 sub default_table_name {
@@ -403,7 +403,7 @@ sub fetch_all_unfinished_jobs_with_no_roles {
     my $self = shift;
 
         # the list should contain all status'es that are not "in progress":
-    return $self->fetch_all( "role_id IS NULL AND status NOT IN ('DONE', 'READY', 'FAILED', 'PASSED_ON', 'SEMAPHORED')" );
+    return $self->fetch_all( "role_id IS NULL AND status IN ('CLAIMED',$ALL_STATUSES_OF_RUNNING_JOBS)" );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
@@ -41,6 +41,8 @@ package Bio::EnsEMBL::Hive::DBSQL::RoleAdaptor;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor;
+
 use base ('Bio::EnsEMBL::Hive::DBSQL::ObjectAdaptor');
 
 
@@ -141,7 +143,7 @@ sub fetch_all_finished_roles_with_unfinished_jobs {
     my $self = shift;
 
         # the list should contain all status'es that are not "in progress":
-    return $self->fetch_all( "JOIN job USING(role_id) WHERE when_finished IS NOT NULL AND status NOT IN ('DONE', 'READY', 'FAILED', 'PASSED_ON', 'SEMAPHORED') GROUP BY role_id" );
+    return $self->fetch_all( "JOIN job USING(role_id) WHERE when_finished IS NOT NULL AND status IN ('CLAIMED',$Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor::ALL_STATUSES_OF_RUNNING_JOBS) GROUP BY role_id" );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
@@ -142,8 +142,7 @@ sub print_active_role_counts {
 sub fetch_all_finished_roles_with_unfinished_jobs {
     my $self = shift;
 
-        # the list should contain all status'es that are not "in progress":
-    return $self->fetch_all( "JOIN job USING(role_id) WHERE when_finished IS NOT NULL AND status IN ('CLAIMED',$Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor::ALL_STATUSES_OF_RUNNING_JOBS) GROUP BY role_id" );
+    return $self->fetch_all( "JOIN job USING(role_id) WHERE when_finished IS NOT NULL AND status IN ($Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor::ALL_STATUSES_OF_TAKEN_JOBS) GROUP BY role_id" );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -71,6 +71,7 @@ use warnings;
 use File::Path 'make_path';
 use List::Util qw(max);
 
+use Bio::EnsEMBL::Hive::AnalysisStats;
 use Bio::EnsEMBL::Hive::Utils::Config;
 use Bio::EnsEMBL::Hive::Utils ('destringify', 'dir_revhash', 'whoami');  # NB: needed by invisible code
 use Bio::EnsEMBL::Hive::Role;
@@ -298,8 +299,7 @@ sub specialize_worker {
             $controlled_semaphore->increase_by( [ $job ] );
         }
 
-        my %status2counter = ('FAILED' => 'failed_job_count', 'READY' => 'ready_job_count', 'DONE' => 'done_job_count', 'PASSED_ON' => 'done_job_count', 'SEMAPHORED' => 'semaphored_job_count');
-        $analysis->stats->adaptor->increment_a_counter( $status2counter{$job->status}, -1, $job->analysis_id );
+        $analysis->stats->adaptor->increment_a_counter( $Bio::EnsEMBL::Hive::AnalysisStats::status2counter{$job->status}, -1, $job->analysis_id );
 
     } else {
 


### PR DESCRIPTION
rather than hard-coding them everywhere

This makes adding/removing statuses easier (e.g. when we get job attempts) but also guarantees all those various methods are kept in sync