### PR TITLE
Expose DBI::st's hash interface through StatementHandle

### DIFF
--- a/t/02.api/reconnect.t
+++ b/t/02.api/reconnect.t
@@ -56,7 +56,11 @@ SKIP: {
 	"-sql \"$find_pid_sql\" | grep -v ID";
     
     my $sth = $dbc->prepare($dbc_query_sql);
+    ok(!$sth->{Active}, 'Statement handle not yet active');
     $sth->execute();
+    ok($sth->{Active}, 'Statement handle now active');
+
+    is_deeply($sth->{NAME}, ['id', 'avalue'], 'Got the correct column names');
 
     my @find_pid_results = `$find_pid_cmd`;
     chomp @find_pid_results;
@@ -75,6 +79,7 @@ SKIP: {
     while (my @values = $sth->fetchrow_array()) {
       $fetched_row_count++;
     }
+    ok(!$sth->{Active}, 'Statement handle not active any more');
     is($fetched_row_count, 10, "were we able to fetch all rows after a db kill");
 }
 


### PR DESCRIPTION
Applications need to access DBI::st hash values (like $sth->{Active}) and
the recent change in StatementHandle broke those.
Here we reenable the hash interface by redirecting all the calls to the
statement handle.

In the end, I think this is the best solution as it provides backwards compatibility for all existing code. In fact, you can notice that the AUTOLOAD was basically already redirecting all the method calls to the DBI::st instance, so it makes sense redirecting the hash methods too !

I have expanded a unit-test to also check some of those sth variables (`Active` and `NAME`) and they work !

I think I could then close Ensembl/ensembl#270 ?