### PR TITLE
Improved scheduler

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -312,10 +312,13 @@ sub estimate_num_required_workers {     # this doesn't count the workers that ar
     # 1) hive_capacity
     my $h_cap = $self->analysis->hive_capacity;
     if( defined($h_cap) and $h_cap>=0) {  # what is the currently attainable maximum defined via hive_capacity?
+        # NOTE: $hive_current_load can be higher than 1, making $h_max lower than 0
         my $hive_current_load = $self->hive_pipeline->get_cached_hive_current_load();
         # Round to 3 places before taking the integral part
         my $h_max = POSIX::floor( sprintf('%.3f', $h_cap * ( 1.0 - $hive_current_load )) );
-        if($h_max < $num_required_workers) {
+        if ($h_max <= 0) {
+            $num_required_workers = 0;
+        } elsif ($h_max < $num_required_workers) {
             $num_required_workers = $h_max;
         }
     }

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -290,6 +290,12 @@ sub estimate_num_required_workers {     # this doesn't count the workers that ar
         }
     }
 
+    # 3) job throughput
+    my $t_max = POSIX::floor( $avg_msec_per_job * ($self->max_jobs_per_msec - $self->hive_pipeline->get_total_job_throughput) );
+    if($t_max < $num_required_workers) {
+        $num_required_workers = $t_max;
+    }
+
     return $num_required_workers;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -77,6 +77,11 @@ sub min_job_runtime_msec {
     return 10;
 }
 
+# How long the stats are valid or. Used in synchronize_AnalysisStats
+sub stats_expiration_date_sec {
+    return 3*60;
+}
+
 
 =head1 AUTOLOADED
 

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -59,6 +59,11 @@ sub min_batch_time {
     return 2*60*1000;
 }
 
+sub desired_claim_interval_msec {
+    # That's 5 per second
+    return 200;
+}
+
 
 =head1 AUTOLOADED
 
@@ -221,9 +226,7 @@ sub get_or_estimate_batch_size {
                                                         # otherwise it is a request for dynamic estimation:
     } elsif( my $avg_msec_per_job = $self->avg_msec_per_job ) {           # further estimations from collected stats
 
-        $avg_msec_per_job = 100 if($avg_msec_per_job<100);
-
-        $batch_size = POSIX::ceil( $self->min_batch_time / $avg_msec_per_job );
+        $batch_size = POSIX::ceil( $self->num_running_workers * $self->desired_claim_interval_msec / $avg_msec_per_job ) || 1;
 
     } else {        # first estimation when no stats are available (take -$batch_size as first guess, if not zero)
         $batch_size = -$batch_size || 1;

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -304,7 +304,8 @@ sub estimate_num_required_workers {     # this doesn't count the workers that ar
     my $h_cap = $self->analysis->hive_capacity;
     if( defined($h_cap) and $h_cap>=0) {  # what is the currently attainable maximum defined via hive_capacity?
         my $hive_current_load = $self->hive_pipeline->get_cached_hive_current_load();
-        my $h_max = POSIX::floor( $h_cap * ( 1.0 - $hive_current_load ) );
+        # Round to 3 places before taking the integral part
+        my $h_max = POSIX::floor( sprintf('%.3f', $h_cap * ( 1.0 - $hive_current_load )) );
         if($h_max < $num_required_workers) {
             $num_required_workers = $h_max;
         }

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -64,6 +64,19 @@ sub desired_claim_interval_msec {
     return 200;
 }
 
+# This is the maximum we've seen pipelines reach. In effect, it mostly limits
+# the analyses that are fast (i.e. 250 msec per job -> 500 workers at most)
+sub max_jobs_per_msec {
+    # That's 2000 per second
+    return 2;
+}
+
+# This is the fastest jobs can be due to the eHive overhead
+# It results in eHive scheduling 20 workers to satisfy $self->max_jobs_per_msec
+sub min_job_runtime_msec {
+    return 10;
+}
+
 
 =head1 AUTOLOADED
 
@@ -274,6 +287,14 @@ sub estimate_num_required_workers {     # this 'max allowed' total includes the 
     }
 
     return $num_required_workers;
+}
+
+
+sub get_job_throughput {
+    my $self = shift;
+
+    my $throughput = $self->num_running_workers / ($self->avg_msec_per_job || $self->min_job_runtime_msec);
+    return $throughput;
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -337,7 +337,9 @@ sub estimate_num_required_workers {     # this doesn't count the workers that ar
 
     # 3) job throughput
     my $t_max = POSIX::floor( $avg_msec_per_job * ($self->max_jobs_per_msec - $self->hive_pipeline->get_total_job_throughput) );
-    if($t_max < $num_required_workers) {
+    if ($t_max < 0) {
+        $num_required_workers = 0;
+    } elsif ($t_max < $num_required_workers) {
         $num_required_workers = $t_max;
     }
 

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -53,9 +53,9 @@ sub unikey {    # override the default from Cacheable parent
 }
 
 
-    ## Minimum amount of time in msec that a worker should run before reporting
-    ## back to the hive. This is used when setting the batch_size automatically.
-sub min_batch_time {
+# Minimum amount of time in msec that a worker should run before reporting
+# back to the hive. This is also used when deciding how many workers to submit
+sub min_worker_runtime {
     return 2*60*1000;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -507,6 +507,7 @@ sub _toString_fields {
 
     # We don't want to default to min_job_runtime_msec
     my ($avg_runtime, $avg_runtime_unit);
+    $self->get_or_estimate_avg_msec_per_job;
     if ($self->avg_msec_per_job) {
         ($avg_runtime, $avg_runtime_unit) = $self->friendly_avg_job_runtime($self->avg_msec_per_job);
     } elsif ($self->{'_estimated_avg_msec_per_job'}) {

--- a/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
+++ b/modules/Bio/EnsEMBL/Hive/AnalysisStats.pm
@@ -82,6 +82,12 @@ sub stats_expiration_date_sec {
     return 3*60;
 }
 
+# Maximum amount of time in seconds it takes to synchronise the stats
+# of an analysis
+sub max_lock_sec {
+    return 3600;
+}
+
 
 =head1 AUTOLOADED
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisStatsAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisStatsAdaptor.pm
@@ -193,5 +193,18 @@ sub increment_a_counter {
     }
 }
 
+
+sub get_seconds_since_locked {
+    my ($self, $analysis_id) = @_;
+
+    my $sql = 'SELECT '  . $self->dbc->_interval_seconds_sql('MAX(when_logged)') . ' FROM analysis_stats_monitor WHERE analysis_id = ? AND sync_lock = 0';
+    my $sth = $self->prepare($sql);
+    $sth->execute($analysis_id);
+    my ($seconds_since_locked) = $sth->fetchrow_array();
+    $sth->finish;
+    return $seconds_since_locked;
+}
+
+
 1;
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/RoleAdaptor.pm
@@ -50,6 +50,13 @@ sub default_table_name {
     return 'role';
 }
 
+sub default_input_column_mapping {
+    my $self    = shift @_;
+    return  {
+        # Add another column based on when_started
+        'when_started' => 'when_started, ' . $self->dbc->_interval_seconds_sql('when_started') . ' seconds_since_when_started',
+    };
+}
 
 sub object_class {
     return 'Bio::EnsEMBL::Hive::Role';

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -22,6 +22,8 @@ package Bio::EnsEMBL::Hive::HivePipeline;
 use strict;
 use warnings;
 
+use List::Util qw(sum);
+
 use Bio::EnsEMBL::Hive::TheApiary;
 use Bio::EnsEMBL::Hive::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Hive::Utils ('stringify', 'destringify', 'throw');
@@ -515,6 +517,13 @@ sub get_cached_hive_current_load {
         }
     }
     return $self->{'_cached_hive_load'};
+}
+
+
+sub get_total_job_throughput {
+    my $self = shift @_;
+    my $collection = $self->collection_of( 'AnalysisStats' );
+    return sum(map { $_->get_job_throughput } $collection->list() );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Limiter.pm
+++ b/modules/Bio/EnsEMBL/Hive/Limiter.pm
@@ -109,7 +109,7 @@ sub preliminary_offer {
         $available_capacity = 0 if($available_capacity<0);
 
         my $product = $available_capacity * $multiplier;
-        my $slots_available = int( "$product" );            # stringification helps to round up things like 0.1*10 (instead of leaving them at 0.99999999)
+        my $slots_available = sprintf('%.f', $product );            # sprintf-ication helps to round up things like 0.1*10 (instead of leaving them at 0.99999999)
 
         my $hit_the_limit = $slots_available<$slots_asked;
 

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -924,7 +924,7 @@ sub print_status_and_return_reasons_to_exit {
         $total_done_jobs    += $stats->done_job_count;
         $total_failed_jobs  += $failed_job_count;
         $total_jobs         += $stats->total_job_count;
-        $cpumsec_to_do      += $stats->ready_job_count * $stats->avg_msec_per_job;
+        $cpumsec_to_do      += $stats->ready_job_count * $stats->get_or_estimate_avg_msec_per_job;
     }
 
     my $total_jobs_to_do        = $total_jobs - $total_done_jobs - $total_failed_jobs - $total_excluded_jobs;         # includes SEMAPHORED, READY, CLAIMED, INPROGRESS

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -769,6 +769,14 @@ sub safe_synchronize_AnalysisStats {
         return 'sync_done_by_friend';
     }
 
+    if ($stats->sync_lock and $stats->adaptor) {
+        if ($stats->adaptor->get_seconds_since_locked($stats->analysis_id) > $stats->max_lock_sec) {
+            printf("Analysis %s has been locked too long. Unlocking it now.\n", $stats->analysis->logic_name);
+            $stats->sync_lock(0);
+            $stats->adaptor->update_sync_lock($stats);
+        }
+    }
+
     unless( ($stats->status eq 'DONE')
          or ( ($stats->status eq 'WORKING') and defined($stats->seconds_since_when_updated) and ($stats->seconds_since_when_updated < $stats->stats_expiration_date_sec) ) ) {
 

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -770,7 +770,7 @@ sub safe_synchronize_AnalysisStats {
     }
 
     unless( ($stats->status eq 'DONE')
-         or ( ($stats->status eq 'WORKING') and defined($stats->seconds_since_when_updated) and ($stats->seconds_since_when_updated < 3*60) ) ) {
+         or ( ($stats->status eq 'WORKING') and defined($stats->seconds_since_when_updated) and ($stats->seconds_since_when_updated < $stats->stats_expiration_date_sec) ) ) {
 
         # In case $stats->sync_lock is set, this is basically giving it one last chance
         my $sql = "UPDATE analysis_stats SET status='SYNCHING', sync_lock=1 ".

--- a/modules/Bio/EnsEMBL/Hive/Role.pm
+++ b/modules/Bio/EnsEMBL/Hive/Role.pm
@@ -57,6 +57,13 @@ sub when_started {
 }
 
 
+sub seconds_since_when_started {
+    my $self = shift;
+    $self->{'_seconds_since_when_started'} = shift if(@_);
+    return $self->{'_seconds_since_when_started'};
+}
+
+
 sub when_finished {
     my $self = shift;
     $self->{'_when_finished'} = shift if(@_);

--- a/modules/Bio/EnsEMBL/Hive/Scheduler.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scheduler.pm
@@ -256,10 +256,6 @@ sub schedule_workers {
                 $meadow_capacity_limiter_hashed_by_type
                     ? $meadow_capacity_limiter_hashed_by_type->{$this_meadow_type}
                     : (),
-                defined($analysis->analysis_capacity)
-                    ? Bio::EnsEMBL::Hive::Limiter->new( "Number of Workers working at '$logic_name' analysis",
-                                                        $analysis->analysis_capacity - $analysis_stats->num_running_workers )
-                    : (),
             );
 
             my $hit_the_limit;
@@ -314,7 +310,7 @@ sub sort_pairs_by_suitability {
         my ($analysis, $stats) = @$pair;
 
             # assuming sync() is expensive, so first trying analyses that have already been sunk:
-        if( ($stats->estimate_num_required_workers > 0) and ($stats->status =~/^(READY|WORKING)$/) ) {
+        if( ($stats->num_running_workers+$stats->estimate_num_required_workers > 0) and ($stats->status =~/^(READY|WORKING)$/) ) {
 
             push @primary_candidates, $pair;
 

--- a/modules/Bio/EnsEMBL/Hive/Scheduler.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scheduler.pm
@@ -247,7 +247,7 @@ sub schedule_workers {
 
                 # setting up all negotiating limiters:
             $queen_capacity_limiter->multiplier( $analysis->hive_capacity );
-            $job_throughput_limiter->multiplier( $analysis->stats->avg_msec_per_job || $analysis->stats->min_job_runtime_msec );
+            $job_throughput_limiter->multiplier( $analysis->stats->get_or_estimate_avg_msec_per_job );
 
             my @limiters = (
                 $submit_capacity_limiter,

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -517,7 +517,7 @@ sub run {
         $self->get_stderr_redirector->push( $worker_log_dir.'/worker.err' );
     }
 
-    my $min_batch_time  = Bio::EnsEMBL::Hive::AnalysisStats::min_batch_time();
+    my $min_runtime     = Bio::EnsEMBL::Hive::AnalysisStats::min_worker_runtime();
     my $job_adaptor     = $self->adaptor->db->get_AnalysisJobAdaptor;
 
     print "\n"; # to clear beekeeper's prompt in case output is not logged
@@ -536,7 +536,7 @@ sub run {
             $self->cause_of_death( $jobs_done_by_batches_loop == $special_batch_length ? 'JOB_LIMIT' : 'CONTAMINATED');
         } else {    # a proper "BATCHES" loop
 
-            while (!$self->cause_of_death and $batches_stopwatch->get_elapsed < $min_batch_time) {
+            while (!$self->cause_of_death and $batches_stopwatch->get_elapsed < $min_runtime) {
                 my $current_role        = $self->current_role;
 
                 if( scalar(@{ $job_adaptor->fetch_all_incomplete_jobs_by_role_id( $current_role->dbID ) }) ) {
@@ -583,7 +583,7 @@ sub run {
         }
 
         # The following two database-updating operations are resource-expensive (all workers hammering the same database+tables),
-        # so they are not allowed to happen too frequently (not before $min_batch_time of work has been done)
+        # so they are not allowed to happen too frequently (not before $min_runtime of work has been done)
         #
         if($jobs_done_by_batches_loop) {
 

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -607,6 +607,7 @@ sub run {
                 $stats->hive_pipeline->invalidate_hive_current_load;
                 if( defined($analysis->hive_capacity) && (0 <= $analysis->hive_capacity) && ($stats->hive_pipeline->get_cached_hive_current_load >= 1.1)
                  or defined($analysis->analysis_capacity) && (0 <= $analysis->analysis_capacity) && ($analysis->analysis_capacity < $stats->num_running_workers)
+                 or $stats->hive_pipeline->get_total_job_throughput >= 1.1 * $stats->max_jobs_per_msec
                 ) {
                     $self->cause_of_death('HIVE_OVERLOAD');
                 }

--- a/t/03.scripts/beekeeper_opts.t
+++ b/t/03.scripts/beekeeper_opts.t
@@ -108,7 +108,7 @@ my $pipeline_url = get_test_url_or_die();
 
     my $worker_nta = $hive_dba->get_NakedTableAdaptor('table_name' => 'worker');
     my $live_worker_rows = $worker_nta->fetch_all("worker.status != 'DEAD'");
-    is(scalar(@$live_worker_rows), 2, 'two workers are not dead');
+    is(scalar(@$live_worker_rows), 1, 'one active worker');
     my @live_worker_ids;
     foreach my $row (@$live_worker_rows) {
         push(@live_worker_ids, $row->{'worker_id'});


### PR DESCRIPTION
## Main changes

Following #45, here is the meat of the change. There are three major new features

1. Automatic setting of the batch-size.

in fact, the feature has been there for a very very long time. I just wasn't very happy with the formula. I now try to achieve 5 claim operations per analysis per second. The estimated batch size is simply the optimal number of jobs to achieve that given the number of running workers and the average runtime of a job.

2. New limiter based on the job throughput

This is similar to `hive_capacity` in the sense that all the analyses will be counted in the same limiter and limit each other, but the difference is that the average runtime of jobs is taken into account. The limiter caps the total _throughput_ (jobs per second) of the pipeline. I've checked most of the Compara databases of the last 6 months or so, and the maximum we could reach is ~2,000 jobs per second. However I will ask feedback on #ensembl-hive

3. Submit fewer workers and ensure they all have enough work to do

The scheduler was very greedy and was basically trying to submit 1 worker per job (before limiting this number according to the capacities). For instance, if there are 20 jobs to run, and we know that the average job runtime is 1 second, eHive will still submit 20 workers even though we could afford submitting a single one. Submitting fewer workers is nicer to LSF, especially if you consider that very short jobs are penalized (the `underrun` exception), and that because workers are not guaranteed to start at the same time, when the 20th worker starts, the analysis may have been depleted.
The scheduler now aims at feeding each worker with ~2 minutes worth of work. There is a mechanism similar to the TailTrimming so that it will still submit a few more workers at the next loop, which helps when job runtimes are heterogeneous and workers get stuck on long jobs.

## Related changes

1. I've made `estimate_num_required_workers` return the number of extra workers needed. In fact, it was used like that in Scheduler although defined as the total number of workers in AnalysisStats, but was working fine only because the limiters were enforced in both.

2. I have added a method in AnalysisStats to estimate `avg_msec_per_job` when no workers have reported their stats yet. This is done by reading how many live workers we have, and how many jobs they've been involved with. Even though MySQL timestamps only store whole seconds, it is still sufficient in most cases as the new mechanisms are mostly effective on very quick analyses

## Other comments

This work is largely motivated by the issues encountered by someone new to eHive and trying to run a pipeline on a large dataset (e.g. LongMultiplication with tens of thousands of jobs). Ideally, people should not bother about batch-size, capacity, and eHive should run sensibly (I guess you'll remember which presentation I'm alluding to).

## Things left to do and test before this PR can be accepted

1. I've tested the automatic batch-size on several large Compara pipelines and it worked well. I have only tested the other changes in small pipelines, but will test them at scale too.

2. By default, the batch-size is set to 1 in Analysis.pm (unless defined otherwise). I will run a few more tests, but I would in fact change that to 0 so that the automatic setting is used and we can tell people to forget having to set batch-size

3. I've defined all the parameters as constants in AnalysisStats, but I feel they should ultimately go to the JSON config file. I think we've already mentioned we should properly version it and use it adequately, and I guess it will become more important now

4. I will need to update the documentation

5. Maybe I should include those explanations in the commit messages themselves ?