### PR TITLE
Various fixes: chdir and Core API

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -40,6 +40,14 @@ use warnings;
 
 use base ('Bio::EnsEMBL::DBSQL::DBConnection');
 
+BEGIN {
+    use Bio::EnsEMBL::ApiVersion;
+    my $ev = software_version();
+    if ($ev > 73) {
+        die "eHive 1.9 is not compatible with the Ensembl Core API post version 73.\n".
+             "Please downgrade your Ensembl Core API, or upgrade eHive (which in fact then does not need the Ensembl Core API any more).\n";
+    }
+}
 
 =head2 url
 

--- a/t/01.utils/redirect_stack.t
+++ b/t/01.utils/redirect_stack.t
@@ -21,6 +21,7 @@ use warnings;
 
 use Test::More tests => 8;
 
+use Cwd 'getcwd';
 use Capture::Tiny ':all';
 use File::Temp qw{tempdir};
 
@@ -30,7 +31,8 @@ BEGIN {
 #########################
 
 my $dir = tempdir CLEANUP => 1;
-my $original = chdir $dir;
+my $original = getcwd;
+chdir $dir;
 
 my $rs_stdout = Bio::EnsEMBL::Hive::Utils::RedirectStack->new(\*STDOUT);
 my $stdout = capture_stdout {

--- a/t/02.api/fetch_and_count_by_multiple_columns.t
+++ b/t/02.api/fetch_and_count_by_multiple_columns.t
@@ -33,6 +33,7 @@ use File::Basename ();
 $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
 
 my $dir = tempdir CLEANUP => 1;
+my $original = Cwd::getcwd;
 chdir $dir;
 
 my $pipeline_url      = 'sqlite:///ehive_test_pipeline_db';
@@ -86,4 +87,6 @@ $job_a->store($another_job);
 is($ada_a->count_all(), 1, "still 1 entry in the analysis_data table");
 
 done_testing();
+
+chdir $original;
 

--- a/t/02.api/naked_table_adaptor.t
+++ b/t/02.api/naked_table_adaptor.t
@@ -31,7 +31,8 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 use Bio::EnsEMBL::Hive::DBSQL::DBAdaptor;
 
 my $dir = tempdir CLEANUP => 1;
-my $orig = chdir $dir;
+my $orig = Cwd::getcwd;
+chdir $dir;
 
 my $sqlite_url = "sqlite:///test_db";
 # -no_sql_schema_version_check is needed because the database does not have the eHive schema

--- a/t/10.pipeconfig/longmult.t
+++ b/t/10.pipeconfig/longmult.t
@@ -32,7 +32,8 @@ use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline runWorker);
 $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
 
 my $dir = tempdir CLEANUP => 1;
-my $original = chdir $dir;
+my $original = Cwd::getcwd;
+chdir $dir;
 
 my $ehive_test_pipeline_urls = $ENV{'EHIVE_TEST_PIPELINE_URLS'} || 'sqlite:///ehive_test_pipeline_db';
 # LongMultWf_conf has to be excluded because runWorker is not able to resync the pipeline in can_respecialize mode, leading to the first worker not completing the pipeline


### PR DESCRIPTION
Whilst looking into the Travis errors for 2.4, I've found that `chdir` does *not* return the current directory ! I've unfortunately assumed this in all the tests :( There will certainly be more tests to fix on the other branches, but I'll do that together with the merge.

Also, since v1.9 is only compatible with the Ensembl Core API up to version 73, I am now checking the version number in the code itself to print a clear error message.