### PR TITLE
Various fixes related to analysis sync-ing

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -759,7 +759,7 @@ sub safe_synchronize_AnalysisStats {
         }
     }
 
-    return 'stats_fresh_enough';
+    return $stats->sync_lock ? 0 : 'stats_fresh_enough';
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Scheduler.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scheduler.pm
@@ -215,16 +215,6 @@ sub schedule_workers {
                 next ANALYSIS;
             }
 
-            # If the analysis is synching, just wait (at most 50 seconds) until the sync is done
-            if ($analysis_stats->sync_lock) {
-                my $max_refresh_attempts = 5;
-                do {
-                    sleep(10);
-                    $analysis_stats->refresh();
-                } while($analysis_stats->sync_lock and $max_refresh_attempts--);   # another Worker/Beekeeper is synching this analysis right now
-
-            } else {
-
                 push @$log_buffer, "Analysis '$logic_name' is ".$analysis_stats->status.", safe-synching it...";
 
                 # Do a (safe) sync to get up-to-date job-counts and status
@@ -237,7 +227,6 @@ sub schedule_workers {
                 } else {
                     push @$log_buffer, "Safe-sync of Analysis '$logic_name' could not be run at this moment, will use old stats.";
                 }
-            }
 
             if( ($analysis_stats->status eq 'BLOCKED') or (($analysis_stats->sync_lock) and scalar(@{ $analysis->control_rules_collection() }))) {
                 push @$log_buffer, "Analysis '$logic_name' is still ".$analysis_stats->status.", skipping it.";


### PR DESCRIPTION
I found those when reviewing the changes I've made around the scheduler. Technically there is only 1 bug, so the other commits probably should be put on master instead.

Changes are about sync-ing an analysis, or waiting for the sync to complete (when being performed by another agent). I think there are a few cases where we don't need to sync again, and a case where we need to report that the sync failed.
The Scheduler can also be simplified and use `safe_synchronize_AnalysisStats`.