### PR TITLE
Added a method in DBConnection that generates the SQL to compute the number of seconds between two timestamps

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisStatsAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisStatsAdaptor.pm
@@ -55,13 +55,8 @@ sub default_table_name {
 
 sub default_input_column_mapping {
     my $self    = shift @_;
-    my $driver  = $self->dbc->driver();
     return  {
-        'when_updated' => {
-                            'mysql'     => "UNIX_TIMESTAMP()-UNIX_TIMESTAMP(when_updated) seconds_since_when_updated ",
-                            'sqlite'    => "strftime('%s','now')-strftime('%s',when_updated) seconds_since_when_updated ",
-                            'pgsql'     => "EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - when_updated) seconds_since_when_updated ",
-        }->{$driver},
+        'when_updated' => $self->dbc->_interval_seconds_sql('when_updated') . ' seconds_since_when_updated',
     };
 }
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -407,5 +407,38 @@ sub requires_write_access {
 }
 
 
+=head2 _interval_seconds_sql
+
+  Argument[1] : String. Name of the column for the start of the interval
+  Argument[2] : String, optional. Name of the column for the end of the interval
+  Example     : $self->dbc->_interval_seconds_sql();
+  Description : Returns an SQL expression to compute the number of seconds betwen both columns.
+                If the second column name is missing, compute the number of seconds until now instead.
+  Returntype  : String
+  Exceptions  : none
+  Caller      : general
+  Status      : Stable
+
+=cut
+
+sub _interval_seconds_sql {
+    my ($self, $column_from, $column_to) = @_;
+
+    my $driver = $self->driver();
+
+    $column_to ||= {
+        'mysql'     => '',
+        'sqlite'    => q{'now'},
+        'pgsql'     => 'CURRENT_TIMESTAMP',
+    }->{$driver};
+
+    return  {
+        'mysql'     => "UNIX_TIMESTAMP($column_to)-UNIX_TIMESTAMP($column_from)",
+        'sqlite'    => "strftime('%s',$column_to)-strftime('%s',$column_from)",
+        'pgsql'     => "EXTRACT(EPOCH FROM $column_to - $column_from)",
+    }->{$driver};
+}
+
+
 1;
 


### PR DESCRIPTION
I would like to use this method in some new adaptor methods I'm writing, and thought it'd be clearer to submit it separately. Even without considering the new code, it actually simplifies the existing adaptors.

The reason for this is that each database driver has its own way of computing the difference between two timestamps. The current adaptors all implement the same switch-case to select the appropriate syntax. This is what I've move to DBConnection.