### PR TITLE
Allow the IF NOT EXISTS option of CREATE DATABASE

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -228,7 +228,7 @@ sub to_cmd {
                 }
                 $dbname = '';
             }
-        } elsif($sqlcmd =~ /(CREATE\s+DATABASE\s*?)(?:\s+(\w+))?/i ) {
+        } elsif($sqlcmd =~ /(CREATE\s+DATABASE(?:\s+IF\s+NOT\s+EXISTS)?\s*?)(?:\s+(\w+))?/i ) {
             $dbname = $2 if $2;
 
             if($driver eq 'sqlite') {


### PR DESCRIPTION
Found this with @marcoooo. `DROP DATABASE` understands `IF EXISTS`, but `CREATE DATABASE` doesn't understand `IF NOT EXISTS`