### PR TITLE
 Fixed the Params API in Python

### DIFF
--- a/scripts/travis_run_tests.sh
+++ b/scripts/travis_run_tests.sh
@@ -26,9 +26,12 @@ if [ "$COVERALLS" = 'true' ]; then
 else
   prove -r t
 fi
-
 rt=$?
-if [ $rt -eq 0 ]; then
+
+(cd wrappers/python3; python3 -m unittest -v eHive.Process)
+rtp=$?
+
+if [[ ($rt -eq 0) && ($rtp -eq 0) ]]; then
   if [ "$COVERALLS" = 'true' ]; then
     echo "Running Devel::Cover coveralls report"
     cover --nosummary -report coveralls
@@ -36,5 +39,5 @@ if [ $rt -eq 0 ]; then
   fi
   exit $?
 else
-  exit $rt
+  exit 255
 fi

--- a/wrappers/python3/eHive/Params.py
+++ b/wrappers/python3/eHive/Params.py
@@ -32,6 +32,10 @@ class ParamInfiniteLoopException(ParamException):
     """Raised when parameters depend on each other, forming a loop"""
     def __str__(self):
         return "Substitution loop has been detected on {0}. Parameter-substitution stack: {1}".format(self.args[0], list(self.args[1].keys()))
+class NullParamException(ParamException):
+    """Raised when a parameter cannot be required because it is null (None)"""
+    def __str__(self):
+        return "{0} is None".format(self.args[0])
 
 
 class ParamContainer(object):


### PR DESCRIPTION
This fixes another issue I've found with @marcoooo yesterday. `self.param_required('a')` is supposed to raise an exception if `a` is _None_ (like in Perl). In fact, when the behaviour of the param* methods was rationalised in Perl, the decisions should have been applied to the Python implementation, but I forgot to do so.
Both implementations should now be consistent and in sync with the manual: https://ensembl-hive.readthedocs.io/en/master/creating_runnables/IO_and_errors.html#parameter-handling