### PR TITLE
Cache CPAN dependencies for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,13 @@ addons:
     - ant
     - graphviz
 
+cache:
+  directories:
+    - $HOME/deps
+
 before_install:
+    - cpanm -nq local::lib
+    - eval "$(perl -Mlocal::lib=${HOME}/deps)"
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-export PERL5LIB=$PWD/bioperl-live:$PWD/modules:$PWD/deps
+export PERL5LIB=$PWD/bioperl-live:$PWD/modules:$PWD/deps:$HOME/deps/lib/perl5
 export TEST_AUTHOR=$USER
 
 COVERALLS="false"


### PR DESCRIPTION
While the decrease in the time taken to test on travis ([before](https://travis-ci.org/kiwiroy/ensembl-hive/builds/447572596) vs [after](https://travis-ci.org/kiwiroy/ensembl-hive/builds/447600045)) isn't as significant as I hoped there is definitely a benefit that the log files are shorter. The ~11 year old 5.10 still dominates the time taken for the integration suite.