### PR TITLE
Protect db_handle methods against "MySQL server has gone away"

### DIFF
--- a/docs/dev/development_guidelines.rst
+++ b/docs/dev/development_guidelines.rst
@@ -57,6 +57,28 @@ Core type. eHive has developed new functionalities in its own
 ``DBSQL::DBConnection``, and has reimplemented ``DBSQL::StatementHandle``
 to allow catching connection errors and automatically reconnecting.
 
+In summary, eHive connections are protected against:
+
+* "MySQL server has gone away" errors through:
+
+  * a reimplementation of ``DBSQL::StatementHandle`` (which allows code to be
+    entirely compatible with the Core API)
+  * allowing to call *dbh* methods on the connection object itself (whilst
+    capturing the error), though this requires the calling code to be updated.
+    In hindsight, it would have been better to implement a new class
+    ``DBSQL::DatabaseHandle`` that would wrap and protect *db_handle* calls the
+    same way ``DBSQL::StatementHandle`` wraps and protects *sth* calls.
+
+    .. note::
+       ``$dbc->db_handle->prepare`` is protected by calling ``$dbc->protected_prepare``
+       because ``DBConnection::prepare()`` already exists.
+
+* Deadlocks and "Lock wait timeout" errors through a new ``protected_prepare_execute``
+  method that combines ``prepare`` and ``execute``. ``protected_prepare_execute`` has
+  to be explicitly called, and is currently only used in critical statements (usually
+  revolving around job semaphores, statuses and log messages.
+
+
 Custom ORM
 ----------
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
@@ -234,16 +234,15 @@ sub _table_info_loader {
     my $self = shift @_;
 
     my $dbc         = $self->dbc();
-    my $dbh         = $dbc->db_handle();
     my $driver      = $dbc->driver();
     my $dbname      = $dbc->dbname();
     my $table_name  = $self->table_name();
 
     my %column_set  = ();
     my $autoinc_id  = '';
-    my @primary_key = $dbh->primary_key(undef, undef, $table_name);
+    my @primary_key = $dbc->primary_key(undef, undef, $table_name);
 
-    my $sth = $dbh->column_info(undef, undef, $table_name, '%');
+    my $sth = $dbc->column_info(undef, undef, $table_name, '%');
     $sth->execute();
     while (my $row = $sth->fetchrow_hashref()) {
         my ( $column_name, $column_type ) = @$row{'COLUMN_NAME', 'TYPE_NAME'};

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
@@ -579,6 +579,7 @@ sub store {
                 or throw("Could not store fields\n\t{$column_key}\nwith data:\n\t(".join(',', @$values_being_stored).')');
 
             if($return_code > 0) {     # <--- for the same reason we have to be explicitly numeric here
+                # FIXME: does this work if the "MySQL server has gone away" ?
                 my $liid = $autoinc_id && $self->dbc->db_handle->last_insert_id(undef, undef, $table_name, $autoinc_id);
                 $self->mark_stored($object, $liid );
                 ++$stored_this_time;

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
@@ -989,6 +989,7 @@ sub AUTOLOAD {
              or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
 
                 warn "trying to reconnect...";
+                # NOTE: parameters set via the hash interface of $dbh will be lost
                 $self->reconnect();
                 my $db_handle = $self->db_handle() or throw( "db_handle returns false" );
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
@@ -960,6 +960,12 @@ sub AUTOLOAD {
     $AUTOLOAD=~/^.+::(\w+)$/;
     my $method_name = $1;
 
+    # Mechanism to call on the dbc a db_handle method
+    # Used for "prepare" because the latter also exists on dbc
+    if ($method_name =~ /^protected_(.*)/) {
+        $method_name = $1;
+    }
+
 #    warn "[AUTOLOAD instantiating '$method_name'] ($AUTOLOAD)\n";
 
     *$AUTOLOAD = sub {
@@ -997,7 +1003,7 @@ sub AUTOLOAD {
             }
         };
 
-        if($self->disconnect_when_inactive()) {
+        if($self->disconnect_when_inactive() && ($method_name !~ /^prepare/)) { # we shouldn't disconnect right after prepare() otherwise the statement handle would be linked to a closed connection
             $self->disconnect_if_idle();
         }
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -377,7 +377,7 @@ sub run_in_transaction {
 sub has_write_access {
     my $self = shift;
     if ($self->driver eq 'mysql') {
-        my $user_entries =  $self->db_handle->selectall_arrayref('SELECT Insert_priv, Update_priv, Delete_priv FROM mysql.user WHERE user = ?', undef, $self->username);
+        my $user_entries =  $self->selectall_arrayref('SELECT Insert_priv, Update_priv, Delete_priv FROM mysql.user WHERE user = ?', undef, $self->username);
         my $has_write_access_from_some_host = 0;
         foreach my $entry (@$user_entries) {
             $has_write_access_from_some_host ||= !scalar(grep {$_ eq 'N'} @$entry);

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBConnection.pm
@@ -344,6 +344,7 @@ sub run_in_transaction {
     my $result;
     eval {
         $result = $callback->();
+        # FIXME: does this work if the "MySQL server has gone away" ?
         $self->db_handle()->commit();
     };
     my $error = $@;

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -50,7 +50,7 @@ sub new {
 
     my $dbi_sth;
     eval {
-        $dbi_sth = $dbc->db_handle->prepare( $sql, $attr );
+        $dbi_sth = $dbc->protected_prepare( $sql, $attr );
         1;
     } or do {
         throw( "FAILED_SQL(".$dbc->dbname."): " . join(' ', $sql, stringify($attr)) . "\nGot: ".$@."\n" );

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -153,6 +153,7 @@ sub AUTOLOAD {
                 $dbc->reconnect();
 
                 warn "trying to re-prepare [$sql". ($attr ? (', '.stringify($attr)) : '') ."]...";
+                # NOTE: parameters set via the hash interface of $sth will be lost
                 $dbi_sth = $dbc->db_handle->prepare( $sql, $attr );
                 $self->dbi_sth( $dbi_sth );
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
@@ -160,7 +160,7 @@ sub fetch_input {
     my @ehive_tables = ();
     {
         ## Only query the list of eHive tables if there is a "hive_meta" table
-        my $meta_sth = $src_dbc->db_handle->table_info(undef, undef, 'hive_meta');
+        my $meta_sth = $src_dbc->table_info(undef, undef, 'hive_meta');
         if ($meta_sth->fetchrow_arrayref) {
             my $src_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -dbconn => $src_dbc, -disconnect_when_inactive => 1, -no_sql_schema_version_check => 1 );
             @ehive_tables = (@{$src_dba->hive_pipeline->list_all_hive_tables}, @{$src_dba->hive_pipeline->list_all_hive_views});
@@ -284,7 +284,7 @@ sub _get_table_list {
         if ($initable =~ /%/) {
             $initable =~ s/_/\\_/g;
         }
-        my $sth = $dbc->db_handle->table_info(undef, undef, $initable, undef);
+        my $sth = $dbc->table_info(undef, undef, $initable, undef);
         push @newtables, map( {$_->[2]} @{$sth->fetchall_arrayref});
     }
     return \@newtables;

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/MySQLTransfer.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/MySQLTransfer.pm
@@ -201,11 +201,11 @@ sub get_row_count {
 sub _assert_same_table_schema {
     my ($self, $src_dbc, $dest_dbc, $table) = @_;
 
-    my $src_sth = $src_dbc->db_handle->column_info(undef, undef, $table, '%');
+    my $src_sth = $src_dbc->column_info(undef, undef, $table, '%');
     my $src_schema = $src_sth->fetchall_arrayref;
     $src_sth->finish();
 
-    my $dest_sth = $dest_dbc->db_handle->column_info(undef, undef, $table, '%');
+    my $dest_sth = $dest_dbc->column_info(undef, undef, $table, '%');
     my $dest_schema = $dest_sth->fetchall_arrayref;
     $dest_sth->finish();
 

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SqlCmd.pm
@@ -112,6 +112,7 @@ sub _exec_sql {
         $data_dbc->do( $sql ) or die "Could not run '$sql': ".$data_dbc->db_handle->errstr;
 
         my $insert_id_name  = '_insert_id_'.$counter++;
+        # FIXME: does this work if the "MySQL server has gone away" ?
         my $insert_id_value = $data_dbc->db_handle->last_insert_id(undef, undef, undef, undef);
 
         $output_id{$insert_id_name} = $insert_id_value;

--- a/scripts/dev/sql2rst.pl
+++ b/scripts/dev/sql2rst.pl
@@ -39,7 +39,7 @@ use Bio::EnsEMBL::Hive::Utils::GraphViz;
 ###############
 
 my ($sql_file,$fk_sql_file,$html_file,$db_team,$show_colour,$version,$header_flag,$sort_headers,$sort_tables,$intro_file,$embed_diagrams,$help,$help_format);
-my ($url,$skip_conn,$db_handle);
+my ($url,$skip_conn,$db_connection);
 
 usage() if (!scalar(@ARGV));
  
@@ -79,10 +79,9 @@ $skip_conn      = undef if ($skip_conn == 0);
 
 # Dababase connection (optional)
 if (defined($url) && !defined($skip_conn)) {
-  my $db_connection = new Bio::EnsEMBL::Hive::DBSQL::DBConnection(
+  $db_connection = new Bio::EnsEMBL::Hive::DBSQL::DBConnection(
     -url => $url,
   ) or die("DATABASE CONNECTION ERROR: Could not get a database adaptor for $url\n");
-  $db_handle = $db_connection->db_handle;
 }
 
 
@@ -1020,7 +1019,7 @@ sub get_example_table {
     $table_name = $table if ($cols eq '*');
     $table_name = $1 if ($col =~ /(\S+)\.\*/ and !defined($table_name));
     if (defined($table_name)) {
-      my $table_cols = $db_handle->selectall_arrayref(qq{SHOW COLUMNS FROM $table_name});
+      my $table_cols = $db_connection->selectall_arrayref(qq{SHOW COLUMNS FROM $table_name});
       foreach my $col (@$table_cols) {
         push(@tcols,$col->[0]);
       }
@@ -1034,7 +1033,7 @@ sub get_example_table {
     push(@tcols,$col);
   }
   
-  my $results = $db_handle->selectall_arrayref($sql);
+  my $results = $db_connection->selectall_arrayref($sql);
   if (scalar(@$results)) {
     my @data;
     push @data, \@tcols;

--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -145,7 +145,6 @@ sub main {
     }
 
     my $hive_dbc = $pipeline->hive_dba->dbc;
-    my $dbh = $hive_dbc->db_handle();
 
     # Get the memory usage from each resource_class
     my %mem_resources = ();
@@ -167,7 +166,7 @@ sub main {
     my %used_res = ();
     if (($mode eq 'memory') or ($mode eq 'cores') or ($mode eq 'pending_workers') or ($mode eq 'pending_time')) {
         my $sql_used_res = 'SELECT worker_id, mem_megs, cpu_sec/lifespan_sec FROM worker_resource_usage';
-        foreach my $db_entry (@{$dbh->selectall_arrayref($sql_used_res)}) {
+        foreach my $db_entry (@{$hive_dbc->selectall_arrayref($sql_used_res)}) {
             my $worker_id = shift @$db_entry;
             $used_res{$worker_id} = $db_entry;
         }
@@ -188,7 +187,7 @@ sub main {
         my $sql = $key eq 'analysis'
             ? 'SELECT when_submitted, when_started, when_finished, worker_id, resource_class_id, analysis_id FROM worker LEFT JOIN role USING (worker_id)'
             : 'SELECT when_submitted, when_born, when_died, worker_id, resource_class_id FROM worker';
-        my @tmp_dates = @{$dbh->selectall_arrayref($sql)};
+        my @tmp_dates = @{$hive_dbc->selectall_arrayref($sql)};
         warn scalar(@tmp_dates), " rows\n" if $verbose;
 
         foreach my $db_entry (@tmp_dates) {

--- a/t/02.api/drop_hive_tables.t
+++ b/t/02.api/drop_hive_tables.t
@@ -40,7 +40,7 @@ SKIP: {
 	      $dbc->do('CALL drop_hive_tables;');
 	    }, 'CALL drop_hive_tables does not fail');
   
-  my $table_list = $dbc->db_handle->selectcol_arrayref('SHOW TABLE STATUS', { Columns => [1] });
+  my $table_list = $dbc->selectcol_arrayref('SHOW TABLE STATUS', { Columns => [1] });
   
   is_deeply( $table_list, [], 'All the eHive tables have been removed by "drop_hive_tables"');
   

--- a/t/02.api/latest_schema_patch.t
+++ b/t/02.api/latest_schema_patch.t
@@ -51,11 +51,11 @@ sub schema_from_url {
     if ($dbc->driver eq 'mysql') {
         # For some reasons, column_info(undef, undef, '%', '%') doesn't
         # work on MySQL ... We need to call it on each table explicitly
-        my $sth = $dbc->db_handle->table_info(undef, undef, '%');
+        my $sth = $dbc->table_info(undef, undef, '%');
         my @table_names = keys %{ $sth->fetchall_hashref('TABLE_NAME') };
         my %schema;
         foreach my $t (@table_names) {
-            $sth = $dbc->db_handle->column_info(undef, undef, $t, '%');
+            $sth = $dbc->column_info(undef, undef, $t, '%');
             $schema{$t} = $sth->fetchall_hashref('ORDINAL_POSITION');
         }
         return \%schema;
@@ -64,7 +64,7 @@ sub schema_from_url {
         # of a column. This means that patches that add columns cannot
         # produce the same new schema, so we can't use the ORDINAL position
         # when comparing the schemas
-        my $sth = $dbc->db_handle->column_info(undef, undef, '%', '%');
+        my $sth = $dbc->column_info(undef, undef, '%', '%');
         my $schema = $sth->fetchall_hashref(['TABLE_NAME', 'COLUMN_NAME']);
         foreach my $s (values %$schema) {
             delete $_->{'ORDINAL_POSITION'} for values %$s;
@@ -72,7 +72,7 @@ sub schema_from_url {
         $sth->finish();
         return $schema;
     } else {
-        my $sth = $dbc->db_handle->column_info(undef, undef, '%', '%');
+        my $sth = $dbc->column_info(undef, undef, '%', '%');
         my $schema = $sth->fetchall_hashref(['TABLE_NAME', 'ORDINAL_POSITION']);
         $sth->finish();
         return $schema;

--- a/t/02.api/reconnect.t
+++ b/t/02.api/reconnect.t
@@ -30,6 +30,29 @@ use Bio::EnsEMBL::Hive::Utils::URL;
 # For finding the sample db dump's location, so it can be loaded.
 $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
 
+
+sub kill_active_connection {
+    my ($dbname, $server_url) = @_;
+    my $find_pid_sql = "SELECT ID FROM information_schema.processlist " .
+      "WHERE DB = '$dbname'";
+    my $find_pid_cmd = $ENV{'EHIVE_ROOT_DIR'}.'/scripts/db_cmd.pl ' .
+      "-url $server_url " .
+	"-sql \"$find_pid_sql\" | grep -v ID";
+
+    my @find_pid_results = `$find_pid_cmd`;
+    chomp @find_pid_results;
+
+    if (scalar(@find_pid_results) > 1) {
+      BAIL_OUT("more than one process id accessing test database (pids: ".join(', ', @find_pid_results)."), bailing out");
+    }
+
+    my ($found_pid) = @find_pid_results;
+
+    my $kill_sql = "KILL $found_pid";
+    run_sql_on_db($server_url, $kill_sql);
+}
+
+
 SKIP: {
     my $db_url = eval { get_test_url_or_die(-driver => 'mysql') };
     skip "no MySQL test database defined", 1 unless $db_url;
@@ -49,11 +72,6 @@ SKIP: {
     my $dbc = make_new_db_from_sqls( $db_url, [ $ENV{'EHIVE_ROOT_DIR'} . '/t/02.api/sql/reconnect_test.sql' ], 'Create database with many rows');
     
     my $dbc_query_sql = "SELECT SQL_NO_CACHE * FROM manyrows";
-    my $find_pid_sql = "SELECT ID FROM information_schema.processlist " .
-      "WHERE DB = '$dbname'";
-    my $find_pid_cmd = $ENV{'EHIVE_ROOT_DIR'}.'/scripts/db_cmd.pl ' .
-      "-url $server_url " .
-	"-sql \"$find_pid_sql\" | grep -v ID";
     
     my $sth = $dbc->prepare($dbc_query_sql);
     ok(!$sth->{Active}, 'Statement handle not yet active');
@@ -62,18 +80,7 @@ SKIP: {
 
     is_deeply($sth->{NAME}, ['id', 'avalue'], 'Got the correct column names');
 
-    my @find_pid_results = `$find_pid_cmd`;
-    chomp @find_pid_results;
-    
-    if (scalar(@find_pid_results) > 1) {
-      BAIL_OUT("more than one process id accessing test database (pids: ".join(', ', @find_pid_results)."), bailing out");
-    }
-    
-    my ($found_pid) = @find_pid_results;
-    
-    my $kill_sql = "KILL $found_pid";
-    run_sql_on_db($server_url, $kill_sql);
-    
+    kill_active_connection($dbname, $server_url);
     
     my $fetched_row_count = 0;
     while (my @values = $sth->fetchrow_array()) {
@@ -81,6 +88,21 @@ SKIP: {
     }
     ok(!$sth->{Active}, 'Statement handle not active any more');
     is($fetched_row_count, 10, "were we able to fetch all rows after a db kill");
+
+    ## Let's now test some dbh methods called by BaseAdaptor
+
+    # -no_sql_schema_version_check is needed because the database does not have the eHive schema
+    my $hive_dba        = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new(-dbconn => $dbc, -no_sql_schema_version_check => 1);
+    my $manyrows_nta    = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'manyrows' );
+    # open a connection and fetch the table schema
+    my $column_set_1    = $manyrows_nta->column_set;
+
+    kill_active_connection($dbname, $server_url);
+
+    # clear the cached value to force fetching it again from the database
+    delete $manyrows_nta->{_column_set};
+    my $column_set_2    = $manyrows_nta->column_set;
+    is_deeply($column_set_2, $column_set_1, 'column_set can be fetched, despite the connection having been killed');
 }
 
 done_testing();


### PR DESCRIPTION
# Use case

The issue was raised by @MatBarba . In ENSCORESW-2913 he managed to identify that a Python Runnable that just sleeps would raise the following error after 30 min:
```
DBD::mysql::db primary_key failed: MySQL server has gone away at (...)/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm line 244, <$CHILD_RDR> line 6.
```
30 min is indeed the timeout parameter of the server he was using.

# Description of the changes

The `primary_key` "dbh" method (and a few others) were indeed called on database handles without checking if the handle is still valid, and without any `eval {}` protection, even though such protection is available via the `AUTOLOAD` in `DBSQL::DBConnection`. The fix is to move those calls from the database handle to the database connection (new "best practice").

`prepare` is slightly more tricky to fix since there is already a `prepare` in `DBConnection`. In this case, I have introduced a fake DBConnection method named `protected_prepare` that calls `prepare` on the database handle with the "MySQL server has gone away" protection, but without disconnecting from the database even if `disconnect_when_inactive` is set. Indeed, `prepare` is most often called on SELECT statements, which are immediately followed by `execute` and `fetch`, both of which expect the database connection to still be open

# Comments

I have added a few comments about pitfalls of the current implementation

# Notes

The change in `has_write_access` will probably clash with the changes that have been accepted upstream. I can easily fix it.