### PR TITLE
Make analysis tags work like logic names

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Analysis.pm
+++ b/modules/Bio/EnsEMBL/Hive/Analysis.pm
@@ -46,7 +46,7 @@ use Bio::EnsEMBL::Hive::GuestProcess;
 
 
 use base ( 'Bio::EnsEMBL::Hive::Storable' );
- 
+
 
 sub unikey {    # override the default from Cacheable parent
     return [ 'logic_name' ];
@@ -112,6 +112,24 @@ sub tags {
     return $self->{'_tags'};
 }
 
+=head2 tag
+
+  Arg [1]    : String (tag regex to search)
+  Example    : $tag_exists = $analysis->tag('blah');
+  Description: provided a tag (which can be a regex) returns the input string if tag exists, returns null if not
+  Returntype : String (the input), or null
+
+=cut
+
+sub tag {
+    my ($self, $tag_regex) = @_;
+
+    if ( grep( /^${tag_regex}$/, @{$self->tags} ) ) {
+        return $tag_regex;
+    }
+
+    return;
+}
 
 sub failed_job_tolerance {
     my $self = shift;
@@ -539,4 +557,3 @@ sub print_diagram_node {
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Hive/Utils/Collection.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Collection.pm
@@ -153,6 +153,9 @@ sub _find_all_by_subpattern {    # subpatterns can be combined into full pattern
     my $filtered_elements = [];
     $pattern //= '';
 
+
+    # dbID specific patterns
+
     if( $pattern=~/^\d+$/ ) {
 
         $filtered_elements = $self->find_all_by( 'dbID', $pattern );
@@ -169,14 +172,28 @@ sub _find_all_by_subpattern {    # subpatterns can be combined into full pattern
 
         $filtered_elements = $self->find_all_by( 'dbID', sub { return $_[0]<=$1; } );
 
+
+    # name/tag specific patterns
+
     } elsif( $pattern=~/^\w+$/) {
 
         $filtered_elements = $self->find_all_by( 'name', $pattern );
+
+        if (!scalar @{$filtered_elements}) {
+            $filtered_elements = $self->find_all_by( 'tag', $pattern );
+        }
 
     } elsif( $pattern=~/^[\w\%]+$/) {
 
         $pattern=~s/\%/.*/g;
         $filtered_elements = $self->find_all_by( 'name', sub { return $_[0]=~/^${pattern}$/; } );
+
+        if (!scalar @{$filtered_elements}) {
+            $filtered_elements = $self->find_all_by( 'tag', $pattern );
+        }
+
+
+    # other patterns
 
     } elsif( $pattern=~/^(\w+)==(.*)$/) {
 

--- a/t/01.utils/collection.t
+++ b/t/01.utils/collection.t
@@ -21,14 +21,12 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
-use Data::Dumper;
 
 BEGIN {
     ## at least it compiles
     use_ok( 'Bio::EnsEMBL::Hive::Utils::Collection' );
     use_ok( 'Bio::EnsEMBL::Hive::ResourceDescription' );
 }
-#########################
 
 my $collection = Bio::EnsEMBL::Hive::Utils::Collection->new(['the']);
 ok($collection, 'and creates objects');
@@ -103,13 +101,13 @@ $result = $collection->find_all_by('foo', undef);
 #is(@$result, 3, 'sensible');
 
 my $data_list = [
-    { 'dbID' => 2, 'name' => 'beta',    'colour' => 'red',      'size' => 10 },
-    { 'dbID' => 1, 'name' => 'alpha',   'colour' => 'orange',   'size' =>  5 },
-    { 'dbID' => 7, 'name' => 'eta',     'colour' => 'yellow',   'size' =>  2 },
-    { 'dbID' => 3, 'name' => 'gamma',   'colour' => 'green',    'size' =>  1 },
-    { 'dbID' => 4, 'name' => 'delta',   'colour' => 'yellow',   'size' => 20 },
-    { 'dbID' => 5, 'name' => 'epsilon', 'colour' => 'orange',   'size' => 25 },
-    { 'dbID' => 6, 'name' => 'zeta',    'colour' => 'red',      'size' =>  0 },
+    { 'dbID' => 2, 'name' => 'beta',    'colour' => 'red',      'size' => 10 , 'tag' => 'red'    },
+    { 'dbID' => 1, 'name' => 'alpha',   'colour' => 'orange',   'size' =>  5 , 'tag' => ''       },
+    { 'dbID' => 7, 'name' => 'eta',     'colour' => 'yellow',   'size' =>  2 , 'tag' => 'yellow' },
+    { 'dbID' => 3, 'name' => 'gamma',   'colour' => 'green',    'size' =>  1                     },
+    { 'dbID' => 4, 'name' => 'delta',   'colour' => 'yellow',   'size' => 20 , 'tag' => 'yellow' },
+    { 'dbID' => 5, 'name' => 'epsilon', 'colour' => 'orange',   'size' => 25 , 'tag' => 'orange' },
+    { 'dbID' => 6, 'name' => 'zeta',    'colour' => 'red',      'size' =>  0 , 'tag' => 'red'    },
 ];
 
 $collection = Bio::EnsEMBL::Hive::Utils::Collection->new( $data_list );
@@ -164,6 +162,12 @@ is(@$mix, 3, 'find_all_by_pattern - greater than');
 
 $mix = $collection->find_all_by_pattern( 'size<10,colour==orange' );
 is(@$mix, 5, 'find_all_by_pattern - selecting by a fields inequality');
+
+$mix = $collection->find_all_by_pattern( 'tag==orange' );
+is(@$mix, 1, 'find_all_by_pattern - selecting by tag field equality');
+
+$mix = $collection->find_all_by_pattern( 'red' );
+is(@$mix, 2, 'find_all_by_pattern - single tag (no %)');
 
 throws_ok {$collection->find_all_by_pattern( 'size!' )} qr/The pattern '.*' is not recognized/, "Using an invalid pattern throws an exception";
 


### PR DESCRIPTION
See https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2558

When runWorker, tweak, etc. try to find analysis, they use `Bio::EnsEMBL::Hive::Utils::Collection->find_all_by_pattern()`.
This ends up defaulting to name.

This pull request adds a fall over search for tags, if no matches exist for name.
Works for searches of a 'tag==word', 'word' and as well as with wildcard 'word%', and is implemented for the collectable that implements tags (i.e. Analysis).
