### PR TITLE
Add a beekeeper option for attempting to stop the whole pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Beekeeper.pm
+++ b/modules/Bio/EnsEMBL/Hive/Beekeeper.pm
@@ -187,5 +187,27 @@ sub check_if_blocked {
     return $self->is_blocked;
 }
 
+
+=head2 toString
+
+  Example     : print $beekeeper->toString();
+  Description : Produces a string summary of properties of this beekeeper.
+  Returntype  : String
+  Exceptions  : none
+  Caller      : general
+  Status      : Stable
+
+=cut
+
+sub toString {
+    my ( $self ) = @_;
+
+    # FIXME: decide what else to add here
+    return join( ', ',
+            'process=' . $self->meadow_user() . '@' . $self->meadow_host() . '#' . $self->process_id(),
+    );
+}
+
+
 1;
 

--- a/modules/Bio/EnsEMBL/Hive/Beekeeper.pm
+++ b/modules/Bio/EnsEMBL/Hive/Beekeeper.pm
@@ -202,9 +202,9 @@ sub check_if_blocked {
 sub toString {
     my ( $self ) = @_;
 
-    # FIXME: decide what else to add here
     return join( ', ',
             'process=' . $self->meadow_user() . '@' . $self->meadow_host() . '#' . $self->process_id(),
+            "options='" . $self->options() . "'",
     );
 }
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/BeekeeperAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/BeekeeperAdaptor.pm
@@ -150,15 +150,14 @@ sub reload_beekeeper_is_blocked {
 =cut
 
 sub block_all_alive_beekeepers {
-  my ( $self ) = @_;
+    my ( $self ) = @_;
 
-  my $statement =
-    'UPDATE beekeeper SET is_blocked = 1 WHERE cause_of_death IS NULL';
-  my $sth = $self->dbc()->prepare( $statement );
-  $sth->execute();
-  $sth->finish();
+    my $statement = 'UPDATE beekeeper SET is_blocked = 1 WHERE cause_of_death IS NULL';
+    my $sth = $self->dbc()->prepare( $statement );
+    $sth->execute();
+    $sth->finish();
 
-  return;
+    return;
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/BeekeeperAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/BeekeeperAdaptor.pm
@@ -131,5 +131,35 @@ sub reload_beekeeper_is_blocked {
 }
 
 
+=head2 block_all_alive_beekeepers
+
+  Example     : $bk_adaptor->block_all_alive_beekeepers();
+  Description : Set is_blocked for all beekeepers known to the
+                pipeline which haven't died yet. Part of the "shut
+                everything down" feature - as eHive stands we cannot
+                tell other beekeepers to kill their respective active
+                workers (unless said workers happen to belong to the
+                same meadow, in which case we can essentially hijack
+                them) but at least we can prevent them from spawning
+                new workers.
+  Returntype  : none
+  Exception   : none
+  Caller      : beekeeper.pl
+  Status      : Stable
+
+=cut
+
+sub block_all_alive_beekeepers {
+  my ( $self ) = @_;
+
+  my $statement =
+    'UPDATE beekeeper SET is_blocked = 1 WHERE cause_of_death IS NULL';
+  my $sth = $self->dbc()->prepare( $statement );
+  $sth->execute();
+  $sth->finish();
+
+  return;
+}
+
 
 1;

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
@@ -136,7 +136,8 @@ sub check_worker_is_alive_and_mine {
 sub kill_worker {
     my ($self, $worker, $fast) = @_;
 
-    system('kill', '-9', $worker->process_id());
+    my $exec_status = system('kill', '-9', $worker->process_id());
+    return ( $exec_status >> 8 );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -177,11 +177,14 @@ sub check_worker_is_alive_and_mine {
 sub kill_worker {
     my ($self, $worker, $fast) = @_;
 
+    my $exec_status;
     if ($fast) {
-        system('bkill', '-r', $worker->process_id());
+        $exec_status = system('bkill', '-r', $worker->process_id());
     } else {
-        system('bkill', $worker->process_id());
+        $exec_status = system('bkill', $worker->process_id());
     }
+
+    return ( $exec_status >> 8 );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -415,9 +415,8 @@ sub kill_all_workers {
             }
         }
 
-        printf( "Killing worker: %10d %35s %15s : %s\n", $worker->dbID(),
-                $worker->meadow_host(), $worker->process_id(),
-                $kill_status );
+        print 'Killing worker ' . $worker->dbID() . ': '
+            . $worker->toString( 1 ) . "\n";
     }
 
     return;

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -389,25 +389,35 @@ sub kill_all_workers {
 
   my $all_workers_considered_alive = $self->fetch_all( "status!='DEAD'" );
   foreach my $worker ( @{ $all_workers_considered_alive } ) {
+    my $kill_status;
+
     my $meadow = $valley->find_available_meadow_responsible_for_worker( $worker );
     if ( ! defined $meadow ) {
       # Most likely a meadow not reachable for the current beekeeper,
       # e.g. a LOCAL one started on a different host.
-      # FIXME: print a warning
+      $kill_status = 'meadow not reachable';
     }
     elsif ( ! $meadow->can('kill_worker') ) {
-      # FIXME: print a warning
+      $kill_status = 'killing workers not supported by the meadow';
     }
     else {
-      # FIXME: the actual termination of a worker might well be
-      # asynchronous but at least we should check for obvious
-      # problems, e.g. insufficient permissions to execute a
-      # kill. This will require changes to kill_worker()
-      # implementations so that one way or another they return some
-      # information about this.
-      $meadow->kill_worker( $worker, 1 );
-      $self->register_worker_death( $worker );
+      # The actual termination of a worker might well be asynchronous
+      # but at least we check for obvious problems, e.g. insufficient
+      # permissions to execute a kill.
+      my $kill_return_value = $meadow->kill_worker( $worker, 1 );
+      if ( $kill_return_value != 0 ) {
+        $kill_status = "request failure (return code: ${kill_return_value})";
+      }
+      else {
+        $kill_status = 'requested successfully';
+        $worker->cause_of_death( 'KILLED_BY_USER' );
+        $self->register_worker_death( $worker );
+      }
     }
+
+    printf( "Killing worker: %10d %35s %15s : %s\n", $worker->dbID(),
+            $worker->meadow_host(), $worker->process_id(),
+            $kill_status );
   }
 
   return;

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -540,10 +540,8 @@ sub big_red_button {
         ! exists $previously_blocked_ids{ $_->dbID() }
     } @{ $blocked_beekeepers };
     while ( my $blocked_bk = shift @currently_blocked ) {
-        # FIXME: decide what else to print
-        printf( "Blocked beekeeper: %10d %35s %35s %15s\n",
-                $blocked_bk->dbID(), $blocked_bk->meadow_host(),
-                $blocked_bk->meadow_user(), $blocked_bk->process_id() );
+        print 'Blocked beekeeper ' . $blocked_bk->dbID() . ': '
+            . $blocked_bk->toString() . "\n";
     }
 
     # Next, kill all workers which are still alive.

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -518,7 +518,18 @@ sub register_beekeeper {
 sub big_red_button {
   my ( $self ) = @_;
 
-  # FIXME: actually do something
+  # Begin by blocking all registered beekeepers so that none of them
+  # start spawning new workers just as this one tries to kill all
+  # workers. FIXME: some message might be in order, possibly showing
+  # the number of blocked beekeepers.
+  # FIXME: temporary, this should go into e.g. BeekeeperAdaptor
+  my $dbc = $self->{dba}->dbc();
+  my $block_sth = $dbc->prepare('UPDATE beekeeper SET is_blocked = 1');
+  $block_sth->execute();
+
+  # FIXME:
+  #  - abort possible pending spawning of workers
+  #  - kill all workers which have already spawned
 
   return 0;
 }

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -342,7 +342,6 @@ sub main {
         }
     }
 
-    # FIXME: maybe we should check this earlier
     if ( $big_red_button ) {
       return big_red_button( $self, $valley );
     }
@@ -534,10 +533,12 @@ sub big_red_button {
     # kill all workers.
     $bk_a->block_all_alive_beekeepers();
 
-    # Report which beekeepers we have just blocked
+    # Report which beekeepers, self excluded, we have just blocked
     $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
+    my $my_dbid = $self->{'beekeeper'}->dbID();
     my @newly_blocked = grep {
-        ! exists $previously_blocked_ids{ $_->dbID() }
+        ( ! exists $previously_blocked_ids{ $_->dbID() } )
+          && ( $_->dbID() != $my_dbid )
     } @{ $blocked_beekeepers };
     while ( my $blocked_bk = shift @newly_blocked ) {
         print 'Blocked beekeeper ' . $blocked_bk->dbID() . ': '

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -522,10 +522,8 @@ sub big_red_button {
   # start spawning new workers just as this one tries to kill all
   # workers. FIXME: some message might be in order, possibly showing
   # the number of blocked beekeepers.
-  # FIXME: temporary, this should go into e.g. BeekeeperAdaptor
-  my $dbc = $self->{dba}->dbc();
-  my $block_sth = $dbc->prepare('UPDATE beekeeper SET is_blocked = 1 WHERE cause_of_death IS NULL');
-  $block_sth->execute();
+  my $bk_a = $self->{dba}->get_Beekeeper();
+  $bk_a->block_all_alive_beekeepers();
 
   # Next, kill all workers which are still alive.
   # FIXME: add some reporting

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -523,9 +523,8 @@ sub big_red_button {
   # workers. FIXME: some message might be in order, possibly showing
   # the number of blocked beekeepers.
   # FIXME: temporary, this should go into e.g. BeekeeperAdaptor
-
   my $dbc = $self->{dba}->dbc();
-  my $block_sth = $dbc->prepare('UPDATE beekeeper SET is_blocked = 1');
+  my $block_sth = $dbc->prepare('UPDATE beekeeper SET is_blocked = 1 WHERE cause_of_death IS NULL');
   $block_sth->execute();
 
   # Next, kill all workers which are still alive.

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -536,10 +536,10 @@ sub big_red_button {
 
     # Report which beekeepers we have just blocked
     $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
-    my @currently_blocked = grep {
+    my @newly_blocked = grep {
         ! exists $previously_blocked_ids{ $_->dbID() }
     } @{ $blocked_beekeepers };
-    while ( my $blocked_bk = shift @currently_blocked ) {
+    while ( my $blocked_bk = shift @newly_blocked ) {
         print 'Blocked beekeeper ' . $blocked_bk->dbID() . ': '
             . $blocked_bk->toString() . "\n";
     }

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -518,7 +518,7 @@ sub register_beekeeper {
 sub big_red_button {
     my ( $self, $valley ) = @_;
 
-    my $bk_a = $self->{dba}->get_Beekeeper();
+    my $bk_a = $self->{dba}->get_BeekeeperAdaptor();
     my $blocked_beekeepers;
 
     # Save a list of IDs of beekeepers which were blocked earlier so

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -61,6 +61,7 @@ sub main {
     my $job_id_for_output           = 0;
     my $show_worker_stats           = 0;
     my $kill_worker_id              = 0;
+    my $big_red_button              = 0;
     my $keep_alive                  = 0;        # DEPRECATED
     my $reset_job_id                = 0;
     my $reset_all_jobs_for_analysis = 0;        # DEPRECATED
@@ -142,6 +143,7 @@ sub main {
                'dead!'             => \$check_for_dead,
                'unkwn!'            => \$bury_unkwn_workers,
                'killworker=i'      => \$kill_worker_id,
+               'big_red_button'    => \$big_red_button,
                'alldead!'          => \$all_dead,
                'balance_semaphores'=> \$balance_semaphores,
                'worker_stats'      => \$show_worker_stats,
@@ -340,6 +342,11 @@ sub main {
         }
     }
 
+    # FIXME: maybe we should check this earlier
+    if ( $big_red_button ) {
+      return big_red_button( $self );
+    }
+
     my $run_job;
     if($run_job_id) {
         eval {$run_job = $self->{'dba'}->get_AnalysisJobAdaptor->fetch_by_dbID( $run_job_id ) or die};
@@ -506,6 +513,16 @@ sub register_beekeeper {
     }
     return $beekeeper;
 }
+
+
+sub big_red_button {
+  my ( $self ) = @_;
+
+  # FIXME: actually do something
+
+  return 0;
+}
+
 
 sub run_autonomously {
     my ($self, $pipeline, $max_loops, $loop_until, $valley, $list_of_analyses, $analyses_pattern, $run_job_id) = @_;
@@ -972,6 +989,10 @@ re-synchronise the ehive
 =item --unkwn
 
 detect all workers in UNKWN state and reset their Jobs for resubmission (careful, they *may* reincarnate!)
+
+=item --big_red_button
+
+shut everything down: block all beekeepers connected to the pipeline and terminate workers
 
 =item --alldead
 

--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -516,44 +516,44 @@ sub register_beekeeper {
 
 
 sub big_red_button {
-  my ( $self, $valley ) = @_;
+    my ( $self, $valley ) = @_;
 
-  my $bk_a = $self->{dba}->get_Beekeeper();
-  my $blocked_beekeepers;
+    my $bk_a = $self->{dba}->get_Beekeeper();
+    my $blocked_beekeepers;
 
-  # Save a list of IDs of beekeepers which were blocked earlier so
-  # that we can not mention them while reporting the current blocking.
-  $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
-  my %previously_blocked_ids;
-  while ( my $blocked_bk = shift @{ $blocked_beekeepers } ) {
-    $previously_blocked_ids{ $blocked_bk->dbID() } = 1;
-  }
+    # Save a list of IDs of beekeepers which were blocked earlier so
+    # that we can not mention them while reporting the current blocking.
+    $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
+    my %previously_blocked_ids;
+    while ( my $blocked_bk = shift @{ $blocked_beekeepers } ) {
+        $previously_blocked_ids{ $blocked_bk->dbID() } = 1;
+    }
 
-  # Begin the shutdown by blocking all registered beekeepers so that
-  # none of them start spawning new workers just as this one tries to
-  # kill all workers.
-  $bk_a->block_all_alive_beekeepers();
+    # Begin the shutdown by blocking all registered beekeepers so that
+    # none of them start spawning new workers just as this one tries to
+    # kill all workers.
+    $bk_a->block_all_alive_beekeepers();
 
-  # Report which beekeepers we have just blocked
-  $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
-  my @currently_blocked = grep {
-    ! exists $previously_blocked_ids{ $_->dbID() }
-  } @{ $blocked_beekeepers };
-  while ( my $blocked_bk = shift @currently_blocked ) {
-    # FIXME: decide what else to print
-    printf( "Blocked beekeeper: %10d %35s %35s %15s\n",
-            $blocked_bk->dbID(), $blocked_bk->meadow_host(),
-            $blocked_bk->meadow_user(), $blocked_bk->process_id() );
-  }
+    # Report which beekeepers we have just blocked
+    $blocked_beekeepers = $bk_a->fetch_all( 'is_blocked = 1' );
+    my @currently_blocked = grep {
+        ! exists $previously_blocked_ids{ $_->dbID() }
+    } @{ $blocked_beekeepers };
+    while ( my $blocked_bk = shift @currently_blocked ) {
+        # FIXME: decide what else to print
+        printf( "Blocked beekeeper: %10d %35s %35s %15s\n",
+                $blocked_bk->dbID(), $blocked_bk->meadow_host(),
+                $blocked_bk->meadow_user(), $blocked_bk->process_id() );
+    }
 
-  # Next, kill all workers which are still alive.
-  # FIXME: double-check correct job status:
-  #  - running ones should be marked as 'failed'
-  #  - claimed but unstarted ones should get back to 'unclaimed'
-  my $queen = $self->{'dba'}->get_Queen();
-  $queen->kill_all_workers( $valley );
+    # Next, kill all workers which are still alive.
+    # FIXME: double-check correct job status:
+    #  - running ones should be marked as 'failed'
+    #  - claimed but unstarted ones should get back to 'unclaimed'
+    my $queen = $self->{'dba'}->get_Queen();
+    $queen->kill_all_workers( $valley );
 
-  return 0;
+    return 0;
 }
 
 

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -63,6 +63,10 @@ beekeeper( $pipeline_url, [ '-big_red_button' ], 'Pipeline shutdown triggered wi
 # Give the worker(s) some time to die
 sleep(10);
 
+my $bk_nta = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'beekeeper' );
+my $unblocked_beekeeper_rows = $bk_nta->fetch_all( 'is_blocked != 1' );
+is( scalar @{ $unblocked_beekeeper_rows }, 0, 'All connected beekeepers have been blocked' );
+
 $hive_dba->dbc->disconnect_if_idle();
 run_sql_on_db( $pipeline_url, 'DROP DATABASE' );
 

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -42,7 +42,7 @@ my $hive_dba =
   Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
 
 # Check that the -big_red_button is recognised
-beekeeper( $pipeline_url, ['-big_red_button'] );
+beekeeper( $pipeline_url, ['-big_red_button'], "beekeper.pl recognises option '-big_red_button'" );
 
 $hive_dba->dbc->disconnect_if_idle();
 run_sql_on_db( $pipeline_url, 'DROP DATABASE' );

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+
+# Copyright [2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package BeekeeperBigRedButtonTests;
+
+use strict;
+use warnings;
+
+use English qw(-no_match_vars);
+use Test::More;
+
+use Bio::EnsEMBL::Hive::Utils::Test
+  qw(init_pipeline runWorker beekeeper get_test_url_or_die run_sql_on_db);
+
+
+# eHive needs this to initialize the pipeline (and run db_cmd.pl)
+$ENV{'EHIVE_ROOT_DIR'} //=
+  File::Basename::dirname(File::Basename::dirname(
+    File::Basename::dirname( Cwd::realpath($PROGRAM_NAME) )
+    ) );
+
+my $pipeline_url = get_test_url_or_die();
+
+init_pipeline(
+  'Bio::EnsEMBL::Hive::Examples::Factories::PipeConfig::LongWorker_conf',
+  $pipeline_url );
+
+my $hive_dba =
+  Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+
+# Check that the -big_red_button is recognised
+beekeeper( $pipeline_url, ['-big_red_button'] );
+
+$hive_dba->dbc->disconnect_if_idle();
+run_sql_on_db( $pipeline_url, 'DROP DATABASE' );
+
+done_testing();
+
+
+1;

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
-# Copyright [2019] EMBL-European Bioinformatics Institute
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -67,6 +67,10 @@ my $bk_nta = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'beekeeper' );
 my $unblocked_beekeeper_rows = $bk_nta->fetch_all( 'is_blocked != 1' );
 is( scalar @{ $unblocked_beekeeper_rows }, 0, 'All connected beekeepers have been blocked' );
 
+my $w_nta = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'worker' );
+my $alive_worker_rows = $w_nta->fetch_all( "status != 'DEAD'" );
+is( scalar @{ $alive_worker_rows }, 0, 'No non-dead workers remaining' );
+
 $hive_dba->dbc->disconnect_if_idle();
 run_sql_on_db( $pipeline_url, 'DROP DATABASE' );
 

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -41,8 +41,27 @@ init_pipeline(
 my $hive_dba =
   Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
 
-# Check that the -big_red_button is recognised
-beekeeper( $pipeline_url, ['-big_red_button'], "beekeper.pl recognises option '-big_red_button'" );
+# Check that the -big_red_button is recognised. Of course if it is it
+# will trigger the shutdown - but all it does at this point is
+# Beekeeper blocking itself, which has no effect because it doesn't
+# actually try to run anything.
+beekeeper( $pipeline_url, [ '-big_red_button' ], "beekeper.pl recognises option '-big_red_button'" );
+
+# This will both spawn a worker to claim a job and register another
+# beekeeper with the pipeline. Ideally we would run this one in loop
+# mode so that we can confirm blocking works, then again having it run
+# in the background so that the test suite can continue would be a bit
+# messy and given it is quicker to block *all* beekeepers than just
+# the active ones, a single-shot run doesn't make that much of a
+# difference.
+beekeeper( $pipeline_url, [ '-run' ] );
+# Give the worker(s) some time to start
+sleep(10);
+
+# Now trigger the shutdown for real
+beekeeper( $pipeline_url, [ '-big_red_button' ], 'Pipeline shutdown triggered without errors' );
+# Give the worker(s) some time to die
+sleep(10);
 
 $hive_dba->dbc->disconnect_if_idle();
 run_sql_on_db( $pipeline_url, 'DROP DATABASE' );

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -64,8 +64,8 @@ beekeeper( $pipeline_url, [ '-big_red_button' ], 'Pipeline shutdown triggered wi
 sleep(10);
 
 my $bk_nta = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'beekeeper' );
-my $unblocked_beekeeper_rows = $bk_nta->fetch_all( 'is_blocked != 1' );
-is( scalar @{ $unblocked_beekeeper_rows }, 0, 'All connected beekeepers have been blocked' );
+my $unblocked_beekeeper_rows = $bk_nta->fetch_all( 'cause_of_death IS NULL AND is_blocked != 1' );
+is( scalar @{ $unblocked_beekeeper_rows }, 0, 'All non-dead beekeepers have been blocked' );
 
 my $w_nta = $hive_dba->get_NakedTableAdaptor( 'table_name' => 'worker' );
 my $alive_worker_rows = $w_nta->fetch_all( "status != 'DEAD'" );

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -20,27 +20,27 @@ package BeekeeperBigRedButtonTests;
 use strict;
 use warnings;
 
-use English qw(-no_match_vars);
+use English qw( -no_match_vars );
 use Test::More;
 
 use Bio::EnsEMBL::Hive::Utils::Test
-  qw(init_pipeline runWorker beekeeper get_test_url_or_die run_sql_on_db);
+    qw( init_pipeline runWorker beekeeper get_test_url_or_die run_sql_on_db );
 
 
 # eHive needs this to initialize the pipeline (and run db_cmd.pl)
 $ENV{'EHIVE_ROOT_DIR'} //=
-  File::Basename::dirname(File::Basename::dirname(
-    File::Basename::dirname( Cwd::realpath($PROGRAM_NAME) )
-    ) );
+  File::Basename::dirname( File::Basename::dirname(
+      File::Basename::dirname( Cwd::realpath($PROGRAM_NAME) )
+  ) );
 
 my $pipeline_url = get_test_url_or_die();
 
 init_pipeline(
-  'Bio::EnsEMBL::Hive::Examples::Factories::PipeConfig::LongWorker_conf',
-  $pipeline_url );
+    'Bio::EnsEMBL::Hive::Examples::Factories::PipeConfig::LongWorker_conf',
+    $pipeline_url );
 
 my $hive_dba =
-  Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+    Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
 
 # Check that the -big_red_button is recognised. Of course if it is it
 # will trigger the shutdown - but all it does at this point is


### PR DESCRIPTION
Block all active Beekeepers, attempt to kill all active workers, report on both. This can fail to shut everything down because the current beekeeper might not be able to reach certain meadows (_e.g._ LOCAL on a different host) or have insufficient permissions to kill certain workers (_e.g._ processes or batch jobs belonging to a different user) but it seems to be all we could do without actively communicating with other Beekeepers and it's better than nothing.
