### PR TITLE
Workaround for IPC::Run compilation failure at pipeline initialisation time

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
@@ -43,6 +43,7 @@ use Bio::EnsEMBL::Hive::Utils ('split_for_bash');
 # --------------------------------------------------------------------------------------------------------------------
 
 BEGIN {
+    eval { require IPC::Run };
     *CORE::GLOBAL::exec = sub {
         return ( ref($_[0]) eq 'ARRAY' ) ? CORE::exec( @{$_[0]} ) : CORE::exec( @_ );
     };


### PR DESCRIPTION
Precompiles IPC::Run before exec is overridden.