### PR TITLE
 Workaround for IPC::Run compilation failure at pipeline initialisation time

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LOCAL.pm
@@ -43,7 +43,7 @@ use Bio::EnsEMBL::Hive::Utils ('split_for_bash');
 # --------------------------------------------------------------------------------------------------------------------
 
 BEGIN {
-    *CORE::GLOBAL::exec = sub {
+    *Proc::Daemon::exec = sub {
         return ( ref($_[0]) eq 'ARRAY' ) ? CORE::exec( @{$_[0]} ) : CORE::exec( @_ );
     };
 }


### PR DESCRIPTION
This is an alternative to #68.

Instead of having to list every module that runs `exec` like this:
```
exec { $args[0] } @args;
```

I've just tried changing the scope of the override and it works on my laptop. Let's give it a try on Travis and the farm !