### PR TITLE
Better diagnostic: tell what events were expected

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -81,7 +81,10 @@ sub standaloneJob {
             ok(Bio::EnsEMBL::Hive::Scripts::StandaloneJob::standaloneJob($module_or_file, $input_id, $flags, undef, $flags->{language}), 'job completed');
         }, sprintf('standaloneJob("%s", %s, (...), %s)', $module_or_file, stringify($param_hash), stringify($flags)));
 
-        ok(!scalar(@$events_to_test), 'no untriggered events') if $expected_events;
+        if ($expected_events) {
+            ok(!scalar(@$events_to_test), 'no untriggered events');
+            diag("Did not receive: " . stringify($events_to_test)) if scalar(@$events_to_test);
+        }
     }
 }
 


### PR DESCRIPTION
This is to help understanding the TAP output for standalone jobs that don't emit all the events they are supposed to emit. It will now stringify and print the missing ones