### PR TITLE
Catch another error message related to lost connection

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
@@ -986,6 +986,7 @@ sub AUTOLOAD {
         } or do {
             my $error = $@;
             if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
+             or $error =~ /Lost connection to MySQL server during query/    # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
              or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
 
                 warn "trying to reconnect...";

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -143,6 +143,7 @@ sub AUTOLOAD {
         } or do {
             my $error = $@;
             if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
+             or $error =~ /Lost connection to MySQL server during query/    # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
              or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
 
                 my $dbc = $self->dbc();


### PR DESCRIPTION
Seeing I need to add the message in two places, I'm wondering if I should introduce a new method, say in DBConnection, that tells whether an error message is due to lost connection, and call it from these two places. I could then add two other methods to tell whether an error message is (1) due to deadlock, (2) due to the unavailability of the server. Both are currently implemented the same way: `if $@ =~ /.../ or ...`