### PR TITLE
Fix lost connection regex from mysql

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
@@ -986,6 +986,7 @@ sub AUTOLOAD {
         } or do {
             my $error = $@;
             if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
+             or $error =~ /Lost connection to MySQL server during query/    # mysql version (alternative message)
              or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
 
                 warn "trying to reconnect...";

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -143,6 +143,7 @@ sub AUTOLOAD {
         } or do {
             my $error = $@;
             if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
+             or $error =~ /Lost connection to MySQL server during query/    # mysql version (alternative message)
              or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
 
                 my $dbc = $self->dbc();


### PR DESCRIPTION
When the mysql connection is lost, mysql clients may send 2 different
messages. This change adds the second one:
"Lost connection to MySQL server during query"
