### PR TITLE
Misc. bugfixes in tweak_pipeline.pl

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -471,10 +471,13 @@ sub apply_tweaks {
                 print "Tweak.Show    \tpipeline.param[$param_name] ::\t"
                      . ($hash_pair ? $hash_pair->{'param_value'} : '(missing_value)') . "\n";
             } elsif($operator eq '#') {
-                $need_write = 1;
-                $pwp_collection->forget_and_mark_for_deletion( $hash_pair );
-
-                print "Tweak.Deleting\tpipeline.param[$param_name] ::\t".stringify($hash_pair->{'param_value'})." --> (missing value)\n";
+                if ($hash_pair) {
+                    $need_write = 1;
+                    $pwp_collection->forget_and_mark_for_deletion( $hash_pair );
+                    print "Tweak.Deleting\tpipeline.param[$param_name] ::\t".stringify($hash_pair->{'param_value'})." --> (missing value)\n";
+                } else {
+                    print "Tweak.Deleting\tpipeline.param[$param_name] skipped (does not exist)\n";
+                }
             } else {
                 $need_write = 1;
                 my $new_value = destringify( $new_value_str );

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -715,14 +715,14 @@ sub apply_tweaks {
 
                     if(my $rd = $self->collection_of( 'ResourceDescription' )->find_one_by('resource_class', $rc, 'meadow_type', $meadow_type)) {
                         my ($submission_cmd_args, $worker_cmd_args) = ($rd->submission_cmd_args, $rd->worker_cmd_args);
-                        print "Tweak.Changing\tresource_class[$rc_name].meadow :: "
+                        print "Tweak.Changing\tresource_class[$rc_name].$meadow_type :: "
                                 .stringify([$submission_cmd_args, $worker_cmd_args])." --> "
                                 .stringify([$new_submission_cmd_args, $new_worker_cmd_args])."\n";
 
                         $rd->submission_cmd_args(   $new_submission_cmd_args );
                         $rd->worker_cmd_args(       $new_worker_cmd_args     );
                     } else {
-                        print "Tweak.Adding  \tresource_class[$rc_name].meadow :: (missing values) --> "
+                        print "Tweak.Adding  \tresource_class[$rc_name].$meadow_type :: (missing values) --> "
                                 .stringify([$new_submission_cmd_args, $new_worker_cmd_args])."\n";
 
                         my ($rd) = $self->add_new_or_update( 'ResourceDescription',   # NB: add_new_or_update returns a list


### PR DESCRIPTION
## Use case

Here are two bugs that I've identified whilst reviewing #62 
1. The tweak query printed back to the user was showing the string `meadow` instead of the actual meadow type.
2. The script allowed deleting non-existing pipeline-wide parameters, which was resulting in Perl warnings about undefined values etc

## Description

1. Print the variable `$meadow_type` instead
2. This had been fixed on 2.5 but not backported. I simply cherry-picked the commit

## Possible Drawbacks

Once this is accepted and merged on the later branches, @mira13 will have to rebase her changes (#62) which may conflict. But it will make her changeset clearer.

## Testing

_Have you added/modified unit tests to test the changes?_

No, there are currently no tests for tweak_pipeline.pl

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, all fine