### PR TITLE
For maintainability use the list of statuses defined in AnalysisJobAdaptor

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -77,6 +77,8 @@ use Bio::EnsEMBL::Hive::Scheduler;
 use Bio::EnsEMBL::Hive::Valley;
 use Bio::EnsEMBL::Hive::Worker;
 
+use Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor;
+
 use base ('Bio::EnsEMBL::Hive::DBSQL::ObjectAdaptor');
 
 sub default_table_name {
@@ -276,7 +278,7 @@ sub specialize_worker {
             or die "Could not fetch job with dbID='$job_id'";
         my $job_status = $job->status();
 
-        if($job_status =~/(CLAIMED|PRE_CLEANUP|FETCH_INPUT|RUN|WRITE_OUTPUT|POST_HEALTHCHECK|POST_CLEANUP)/ ) {
+        if ($Bio::EnsEMBL::Hive::DBSQL::AnalysisJobAdaptor::ALL_STATUSES_OF_TAKEN_JOBS =~ /'$job_status'/) {
             die "Job with dbID='$job_id' is already in progress, cannot run";   # FIXME: try GC first, then complain
         } elsif($job_status =~/(DONE|SEMAPHORED)/ and !$force) {
             die "Job with dbID='$job_id' is $job_status, please use --force to override";


### PR DESCRIPTION


## Requirements

## Use case

I had missed this occurrence when I introduced the variable in 1d3cab12016a667263827192cc8249e56eedfb7d
The goal was to minimize the number of places with an hardcoded list of statuses so that most of the code will still work if somehow the list is changed

## Description

Import the module and use the variable

## Possible Drawbacks

None I can think of

## Testing

_Have you added/modified unit tests to test the changes?_

No, there is currently no test for `runWorker.pl --job_id`. Should I add one ? I can maybe add this to `t/03.scripts/beekeeper_reset.t`:
1. Try running a worker on the job_id of a READY job. It should return 0 and the job will be DONE
2. Try running a worker on the same job_id. It should return !=0 because the job is DONE. `when_completed` should not change
3. Try running a worker on the same job_id but with `--force`. It should accept it and `when_completed` will change

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

All fine