### PR TITLE
docs/dev/build_the_docs: use direct links to requirements.txt

### DIFF
--- a/docs/dev/build_the_docs.rst
+++ b/docs/dev/build_the_docs.rst
@@ -7,10 +7,10 @@ Python environment
 The manual is written in RestructuredText_ and is built with Sphinx_. It
 relies on a number of Python modules.
 
-Locally, install these two requirements file:
+Locally, install Python dependencies using these two requirements files:
 
-* https://github.com/Ensembl/python-requirements/blob/master/readthedocs/requirements.txt
-* https://github.com/Ensembl/ensembl-hive/blob/master/requirements.txt
+* https://raw.githubusercontent.com/Ensembl/python-requirements/master/readthedocs/requirements.txt
+* https://raw.githubusercontent.com/Ensembl/ensembl-hive/master/requirements.txt
 
 On the EBI farm, those are already installed and you only need to activate
 the `ehive_sphinx` environment with ``pyenv local ehive_sphinx``.


### PR DESCRIPTION
## Use case

The links previously used here were, in spite of having .txt at the end, to respective GitHub HTML pages, which could come as a surprise to someone who saved the links directly from the ReadTheDocs page and then tried to feed the resulting files - with names still ending in .txt - to
pip. Using direct links both is less confusing and saves one click each, regardless of whether one downloads the files or just passes links directly to 'pip -r'.

## Description

Replaced old requirements.txt links in _docs/dev/build_the_docs.rst_ to ones pointing directly to raw content.

## Possible Drawbacks

None I can think of.

## Testing

_Have you added/modified unit tests to test the changes?_

no

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_
 
I have rebuilt HTML documentation. Everything parses correctly and _build_the_docs.html_ contains correct, updated links.