### PR TITLE
Have Sphinx use sphinx.ext.imgmath instead of sphinx.ext.pngmath

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ from xhive import setup_if_needed
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.graphviz',
     'sphinxcontrib.doxylink',
     'xhive.code_doc',


### PR DESCRIPTION
## Use case

The Sphinx extension _sphinx.ext.pngmath_ is deprecated, which presumably means it will disappear at some point. There seem to be only two places in eHive documentation which rely on this yet we do use it.

## Description

_sphinx.ext.imgmath_ is a drop-in replacement for it _sphinx.ext.pngmath_ (its default output format is PNG and under the bonnet both use dvipng) so all this PR does is update the Sphinx configuration file to use the former. Now not only do we no longer get the deprecation warning but could now easily switch to SVG output by passing '-D imgmath_image_format=svg' to _sphinx-build_.

## Possible Drawbacks

Sphinx versions older than 1.4 will no longer be supported. Mind you, 1.4 just under 3 years old now and our requirements file already demands 1.6.5.

## Testing

_Have you added/modified unit tests to test the changes?_

no

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

I have rebuilt HTML documentation with _imgmath_, for both PNG and SVG output. No problems in either case.
