### PR TITLE
docs/xhive: support both python2 and python3

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 2.7
+  version: 3.6
   install:
     - requirements: requirements.txt
 

--- a/docs/xhive/__init__.py
+++ b/docs/xhive/__init__.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# For python2 compatibility
+from __future__ import print_function
+
 import json
 import os.path
 import subprocess
@@ -56,7 +59,7 @@ def setup_if_needed(this_release, run_doxygen):
             subprocess.check_call([mkdoxygen_path, doxygen_target])
 
     with open(release_holder, "w") as fh:
-        print >> fh, this_release,
+        print(this_release, end=' ', file=fh)
 
     return doxygen_target
 

--- a/docs/xhive/analysis_diagram.py
+++ b/docs/xhive/analysis_diagram.py
@@ -135,7 +135,7 @@ def generate_dot_diagram(pipeconfig_content):
     graph_path = os.path.join(os.environ["EHIVE_ROOT_DIR"], "scripts", "generate_graph.pl")
     dotcontent = subprocess.check_output([graph_path, "-pipeconfig", pipeconfig_fh.name, "--format", "dot", "-config_file", default_config_file, "-config_file", json_filename], stderr=sys.stderr)
 
-    return dotcontent
+    return dotcontent.decode()
 
 
 def cleanup_tmp_files(app, exception):

--- a/docs/xhive/analysis_diagram.py
+++ b/docs/xhive/analysis_diagram.py
@@ -33,6 +33,9 @@
 # The directive will show side-by-side the pipeconfig code and the
 # diagram it models
 
+# For python2 compatibility
+from __future__ import print_function
+
 import json
 import os.path
 import subprocess
@@ -108,9 +111,8 @@ def generate_dot_diagram(pipeconfig_content):
     # A temporary file for the JSON config
     global json_filename
     if json_filename is None:
-        json_fh = tempfile.NamedTemporaryFile(dir = "_build", delete = False)
-        #print "json_fh:", json_fh.name
-        print >> json_fh, display_config_json
+        json_fh = tempfile.NamedTemporaryFile(mode='w+', dir="_build", delete=False)
+        print(display_config_json, file=json_fh)
         json_fh.close()
         json_filename = json_fh.name
 
@@ -120,14 +122,13 @@ def generate_dot_diagram(pipeconfig_content):
     # A temporary file for the sample PipeConfig
     global pipeconfig_filename
     if pipeconfig_filename is None:
-        pipeconfig_fh = tempfile.NamedTemporaryFile(suffix = '.pm', dir = "_build", delete = False)
+        pipeconfig_fh = tempfile.NamedTemporaryFile(mode='w+', suffix='.pm', dir="_build", delete=False)
         pipeconfig_filename = pipeconfig_fh.name
     else:
         pipeconfig_fh = open(pipeconfig_filename, "w")
 
     package_name = "_build::" + os.path.basename(pipeconfig_fh.name)[:-3]
-    #print "pipeconfig:", pipeconfig_fh.name, package_name
-    print >> pipeconfig_fh, pipeconfig_template % (package_name, pipeconfig_content)
+    print(pipeconfig_template % (package_name, pipeconfig_content), file=pipeconfig_fh)
     pipeconfig_fh.close()
 
     # Run generate_graph and read the content of the dot file

--- a/docs/xhive/code_doc.py
+++ b/docs/xhive/code_doc.py
@@ -54,7 +54,7 @@ class IncludeCommand(Directive):
         try:
             docutils_input = io.StringInput(source=content)
             rawtext = docutils_input.read()
-        except IOError, error:
+        except IOError as error:
             # Show the content
             raise self.severe(u'Problems with "%s" command:\n%s.' % ''.join(self.options['command']), ErrorString(error))
         include_lines = statemachine.string2lines(rawtext, 4, convert_whitespace=True)

--- a/docs/xhive/code_doc.py
+++ b/docs/xhive/code_doc.py
@@ -43,6 +43,14 @@ import sys
 from docutils import io, nodes, statemachine
 from docutils.parsers.rst import Directive, directives
 
+
+# Shamelessly stolen from six
+if (sys.version_info[0] == 3):
+    string_type = str
+else:
+    string_type = basestring
+
+
 class IncludeCommand(Directive):
     required_arguments = 0
     option_spec = {
@@ -66,7 +74,7 @@ class IncludeCommand(Directive):
 
     def get_content(self):
         command = self.get_command()
-        if isinstance(command, basestring):
+        if isinstance(command, string_type):
             return subprocess.check_output(command, stderr=sys.stderr, shell=True)
         else:
             return subprocess.check_output(command, stderr=sys.stderr)


### PR DESCRIPTION
## Use case

See ENSCORESW-3081: Read the Docs is now actively pushing towards using Python3 for documentation building, the custom modules we use in the process are Python2-specific, and we would like to make the switch before RtD drop Python2 support - which is likely to happen sooner rather than later because Python2.7 reaches end of life in 2020.

## Description

Adapt Python2-specific code in our custom documentation-building modules so that it works with both Python2 and Python3. This is done in a Python3-centric way in order to minimise the effort of dropping Python2 support once we have decided to do so.

## Possible Drawbacks

Slight overhead incurred by cross-version compatibility code. Temporary files are no longer opened in binary mode so there is a risk of the code no longer working as expected under Windows, assuming it has ever worked under Windows.

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

n/a

_Have you run the entire test suite and no regression was detected?_

I have successfully built HTML documentation using updated code under both Python2.7 and Python3.6. Haven't tried 3.7 but as far as I can see in the documentation, none of the changes between 3.6 and 3.7 are relevant to us.