### PR TITLE
[ENSCORESW-3082, ENSCORESW-3080] Add .readthedocs.yml config file specifying stable build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+python:
+  version: 2.7
+  install:
+    - requirements: requirements.txt
+
+build:
+   image: stable


### PR DESCRIPTION
## Use case

From time to time readthedocs.io changes the build container (and underlying Ubuntu version) that it uses to build documentation. When the Ubuntu version of the container changes, it breaks our documentation build, because our build relies on several external dependencies. These dependencies are satisfied by downloading and extracting specific .deb packages (specified in docs/rtd_upgrade.sh) which are specific to a specific Ubuntu version. By specifying a specific build container version, we can minimize the frequency of build-breaking upgrades, and easily update the specific .deb packages in rtd_upgrade.sh if needed.

## Description

Add .readthedocs.yml configuration file that specifies that rtd use the "stable" build container image.

## Possible Drawbacks

This file will need to be maintained. In case of conflicts between .readthedocs.yml and settings in the settings interface of the readthedocs.io admin site, it appears that the values set via the website override settings in the config file, which could cause confusion.

## Testing

_Have you added/modified unit tests to test the changes?_

Tested using a separate build project on readthedocs.io

_If so, do the tests pass/fail?_

Build successful, including autogenerated diagrams and doxygen

_Have you run the entire test suite and no regression was detected?_
Yes

