### PR TITLE
More Perl version upgrades

### DIFF
--- a/docs/quickstart/install.rst
+++ b/docs/quickstart/install.rst
@@ -9,7 +9,7 @@ Prerequisites
 eHive system depends on the following components that you may need to
 download and install first:
 
-#. Perl 5.10 `or higher <http://www.perl.org/get.html>`__
+#. Perl 5.14 `or higher <http://www.perl.org/get.html>`__
 #. A database engine of your choice. eHive keeps its state in a
    database, so you will need
 

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -20,7 +20,7 @@ export TEST_AUTHOR=$USER
 
 COVERALLS="false"
 
-if [ "$PERLBREW_PERL" = '5.10' ]; then
+if [ "$PERLBREW_PERL" = '5.14' ]; then
     echo "Testing with Coveralls"
     COVERALLS="true"
 fi


### PR DESCRIPTION
## Use case

I have noticed that the Travis builds were strangely quick, as if Devel::Cover was not enabled. Indeed, it was still attached to Perl 5.10 !
Then I've found another document that was still referencing to 5.10

## Description

I've changed the version in both places.

## Possible Drawbacks

Slower Travis build times on 5.14, but at least we get code coverage statistics

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

N/A