### PR TITLE
Shared module to detect the SQL errors

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/CoreDBConnection.pm
@@ -76,6 +76,7 @@ use DBI;
 use Bio::EnsEMBL::Hive::DBSQL::StatementHandle;
 
 use Bio::EnsEMBL::Hive::Utils ('throw');
+use Bio::EnsEMBL::Hive::Utils::SQLErrorParser;
 
 
 use vars qw(@ISA);      # If Ensembl Core code is available, inherit from its' DBConnection for compatibility.
@@ -986,9 +987,7 @@ sub AUTOLOAD {
             1;
         } or do {
             my $error = $@;
-            if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
-             or $error =~ /Lost connection to MySQL server during query/    # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
-             or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
+            if (Bio::EnsEMBL::Hive::Utils::SQLErrorParser::is_connection_lost($self->driver, $error)) {
 
                 warn "trying to reconnect...";
                 # NOTE: parameters set via the hash interface of $dbh will be lost

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -43,6 +43,7 @@ use strict;
 no strict 'refs';
 use warnings;
 use Bio::EnsEMBL::Hive::Utils ('throw', 'stringify');
+use Bio::EnsEMBL::Hive::Utils::SQLErrorParser;
 
 
 sub new {
@@ -142,11 +143,9 @@ sub AUTOLOAD {
             1;
         } or do {
             my $error = $@;
-            if( $error =~ /MySQL server has gone away/                      # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
-             or $error =~ /Lost connection to MySQL server during query/    # mysql version  ( test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec)
-             or $error =~ /server closed the connection unexpectedly/ ) {   # pgsql version
+            my $dbc = $self->dbc();
+            if (Bio::EnsEMBL::Hive::Utils::SQLErrorParser::is_connection_lost($dbc->driver, $error)) {
 
-                my $dbc = $self->dbc();
                 my $sql = $self->sql();
                 my $attr = $self->attr();
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/StatementHandle.pm
@@ -60,7 +60,7 @@ sub new {
 
     my $real_self = {};
     # $self will remain empty whereas $real_self will actually have all the data
-    # It's only purpose is to offer a hash-reference on which perl allows
+    # Its only purpose is to offer a hash-reference on which perl allows
     # calling hash accessors, e.g. $sth->{Active}
     tie %$self, 'DBIstHashProxy', $dbi_sth, $real_self;
 

--- a/modules/Bio/EnsEMBL/Hive/Utils/SQLErrorParser.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/SQLErrorParser.pm
@@ -1,0 +1,100 @@
+=pod 
+
+=head1 NAME
+
+Bio::EnsEMBL::Hive::Utils::SQLErrorParser
+
+=head1 DESCRIPTION
+
+A collection of functions that recognize common SQL errors of each parser.
+
+These functions are typically called by DBConnection, CoreDBConnection and StatementHandle.
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+
+=head1 CONTACT
+
+Please subscribe to the Hive mailing list:  http://listserver.ebi.ac.uk/mailman/listinfo/ehive-users  to discuss Hive-related questions or to be notified of our updates
+
+=cut
+
+
+package Bio::EnsEMBL::Hive::Utils::SQLErrorParser;
+
+use strict;
+use warnings;
+
+
+=head2 is_connection_lost
+
+    Description: Return 1 if the error message indicates the connection has been closed without us asking
+
+=cut
+
+sub is_connection_lost {
+    my ($driver, $error) = @_;
+
+    if ($driver eq 'mysql') {
+        return 1 if $error =~ /MySQL server has gone away/;                     # test by setting "SET SESSION wait_timeout=5;" and waiting for 10sec
+        return 1 if $error =~ /Lost connection to MySQL server during query/;   # a variant of the same error
+
+    } elsif ($driver eq 'pgsql') {
+        return 1 if $error =~ /server closed the connection unexpectedly/;
+
+    }
+    return 0;
+}
+
+
+=head2 is_server_too_busy
+
+    Description: Return 1 if the error message indicates we can't connect to the server because of a lack
+                 of resources (incl. available connections)
+
+=cut
+
+sub is_server_too_busy {
+    my ($driver, $error) = @_;
+
+    if ($driver eq 'mysql') {
+        return 1 if $error =~ /Could not connect to database.+?failed: Too many connections/s;                             # problem on server side (configured with not enough connections)
+        return 1 if $error =~ /Could not connect to database.+?failed: Can't connect to \w+? server on '.+?' \(99\)/s;     # problem on client side (cooling down period after a disconnect)
+        return 1 if $error =~ /Could not connect to database.+?failed: Can't connect to \w+? server on '.+?' \(110\)/s;    # problem on server side ("Connection timed out"L the server is temporarily dropping connections until it reaches a reasonable load)
+        return 1 if $error =~ /Could not connect to database.+?failed: Lost connection to MySQL server at 'reading authorization packet', system error: 0/s;     # problem on server side (server too busy ?)
+
+    }
+    return 0;
+}
+
+
+=head2 is_deadlock
+
+    Description: Return 1 if the error message indicates the current transaction had to be aborted because
+                 of concurrency issues
+
+=cut
+
+sub is_deadlock {
+    my ($driver, $error) = @_;
+
+    if ($driver eq 'mysql') {
+        return 1 if $error =~ /Deadlock found when trying to get lock; try restarting transaction/;
+        return 1 if $error =~ /Lock wait timeout exceeded; try restarting transaction/;
+    }
+    return 0;
+}
+
+
+1;


### PR DESCRIPTION
## Use case

This is a follow-up of #73 . Several modules check the SQL error to reconnect, restart the transaction, etc, and sometimes several modules share the exact same piece of code.

## Description

I have created a new module that catalogues the various error messages known to each driver. Consumers (usually *DBConnection and StatementHandle) can then use helper functions to detect whether the message is of a certain error or not

## Possible Drawbacks

None I can think ok

## Testing

_Have you added/modified unit tests to test the changes?_

No, there are already some tests for that

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes