### PR TITLE
[ENSCORESW-3077] Travis: Unify configuration of Slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,10 @@ notifications:
     on_success: always
     on_failure: always
   slack:
-    secure: "fbxQ+yuUAKKI10MUmNeCUbLqmVoOHUhGdM2KetqT5DmSn2rHxb099040Ira2tBYmUEPb5QvIMfPZ1xgS27he4xsZIpvOLsd1Or9OOL8XqyeTLcZ/IG4rpky0ehltVXs3s4ClM+YXwCHIoR2FwVghLVn6znmRkYm3TreSDtEUC2o="
+    rooms:
+      - secure: gL6s4PRts/S293qOTVDFub8i7DWxqXVpDz5il8Vx7LxSYgOiA9AJcbT1zuXxhfONA5RwXJ62gRze0LllDcAS9TiUl199SSq7x+hBMBKzGxWV5I0P6m5aPMRi2vdC4yiATMQYF97PaH3zWobEDiGEHRAS+mkGNBExXY1hwZSasy8=
+      - secure: XUShBwss607RlWDQyn4tkVDX390+aIXv1ntaUzr9MtsXMpCNm5X/7PPle7Cq6FZ57vHzkIOM0+FM3kIou7vbc3ediwHEv9/o8PwDah7xH46/ukjCsI+labR6jxoX8YX9SRvUUm4FV9Vo2gkWi0IYM+k+VI6AyDFyhEzyJOIGHEY=
+    on_failure: change
 
 # Get the matrix to only build coveralls support when on 5.14
 matrix:
@@ -37,4 +40,3 @@ matrix:
       env: COVERALLS=true
     - perl: "5.26"
       env: COVERALLS=false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ notifications:
     on_failure: always
   slack:
     rooms:
+      # coregithub
       - secure: gL6s4PRts/S293qOTVDFub8i7DWxqXVpDz5il8Vx7LxSYgOiA9AJcbT1zuXxhfONA5RwXJ62gRze0LllDcAS9TiUl199SSq7x+hBMBKzGxWV5I0P6m5aPMRi2vdC4yiATMQYF97PaH3zWobEDiGEHRAS+mkGNBExXY1hwZSasy8=
+      # ehive-commits
       - secure: XUShBwss607RlWDQyn4tkVDX390+aIXv1ntaUzr9MtsXMpCNm5X/7PPle7Cq6FZ57vHzkIOM0+FM3kIou7vbc3ediwHEv9/o8PwDah7xH46/ukjCsI+labR6jxoX8YX9SRvUUm4FV9Vo2gkWi0IYM+k+VI6AyDFyhEzyJOIGHEY=
     on_failure: change
 


### PR DESCRIPTION
Use the same Slack access token for #coregithub as well as the same notification configuration for all Infrastructure repositories. Notifications to #ehive-commits are still sent.