### PR TITLE
Makes Dumper (and stringify) faster

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils.pm
@@ -89,6 +89,7 @@ sub stringify {
     local $Data::Dumper::Pair      = ' => ';    # make sure we always produce Perl-parsable structures, no matter what is set externally
     local $Data::Dumper::Maxdepth  = 0;         # make sure nobody can mess up stringification by setting a lower Maxdepth
     local $Data::Dumper::Deepcopy  = 1;         # avoid self-references in case the same structure is reused within params
+    local $Data::Dumper::Sparseseen= 1;         # optimized "seen" hash of scalars
 
     return Dumper($structure);
 }


### PR DESCRIPTION
## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

This is from the Perl documentation:
> ```$Data::Dumper::Sparseseen or  $OBJ->Sparseseen([NEWVAL])```
>
> By default, Data::Dumper builds up the "seen" hash of scalars that it has encountered during serialization. This is very expensive.  This seen hash is necessary to support and even just detect circular references. It is exposed to the user via the "Seen()" call both for writing and reading.
>
> If you, as a user, do not need explicit access to the "seen" hash, then you can set the "Sparseseen" option to allow Data::Dumper to eschew building the "seen" hash for scalars that are known not to possess more than one reference. This speeds up serialization considerably if you use the XS implementation.
>
> Note: If you turn on "Sparseseen", then you must not rely on the content of the seen hash since its contents will be an implementation detail!

TBH, I don't know exactly how faster it is, but `stringify` is called so many times I can't see any reasons why not to enable this option.

## Description

_Using one or more sentences, describe the proposed changes and how they are implemented._

Like the other `Data::Dumper` options, I've enabled it locally

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

External code may be calling our `stringify` while relying on `Data::Dumper`'s "Seen" dictionary. I think they could just call `Data::Dumper` directly instead

## Testing

_Have you added/modified unit tests to test the changes?_

No: `stringify` is already used in so many places

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes. All good