### PR TITLE
Bugfix: RunWorkerPath erroneously prefixed with "/" if set to empty string

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow.pm
@@ -203,8 +203,10 @@ sub pipeline_name {
 sub runWorker_path {
     my $self = shift @_;
 
-    my $path = $self->config_get('RunWorkerPath') // $ENV{'EHIVE_ROOT_DIR'}.'/scripts/';
-    $path = $path . '/' unless $path =~ /\/$/;
+    my $path = $self->config_get('RunWorkerPath') // $ENV{'EHIVE_ROOT_DIR'}.'/scripts/'; 
+    if ( length($path ) { 
+      $path = $path . '/' unless $path =~ /\/$/; # add "/" as suffix if user forgot  
+    }
     return $path;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/Meadow.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow.pm
@@ -203,9 +203,9 @@ sub pipeline_name {
 sub runWorker_path {
     my $self = shift @_;
 
-    my $path = $self->config_get('RunWorkerPath') // $ENV{'EHIVE_ROOT_DIR'}.'/scripts/'; 
+    my $path = $self->config_get('RunWorkerPath') // $ENV{'EHIVE_ROOT_DIR'}.'/scripts/';
     if ( length($path) ) { 
-      $path = $path . '/' unless $path =~ /\/$/; # add "/" as suffix if user forgot  
+        $path = $path . '/' unless $path =~ /\/$/; # add "/" as suffix if user forgot
     }
     return $path;
 }

--- a/modules/Bio/EnsEMBL/Hive/Meadow.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow.pm
@@ -204,7 +204,7 @@ sub runWorker_path {
     my $self = shift @_;
 
     my $path = $self->config_get('RunWorkerPath') // $ENV{'EHIVE_ROOT_DIR'}.'/scripts/'; 
-    if ( length($path ) { 
+    if ( length($path) ) { 
       $path = $path . '/' unless $path =~ /\/$/; # add "/" as suffix if user forgot  
     }
     return $path;


### PR DESCRIPTION
## Description

Bugfix ;   If user configured RunWorkerPath to be empty string in hive_config.json
the runWorker script got erroneously prefixed with "/runWorker.pl"; 

According to the REMARKS in hive_config.json runWorker.pl is in PATH when set to empty string - so prefix with "/runWorker.pl" breaks code

## Possible Drawbacks

N/A

## Testing

- No unit test in code base for runWorker_path() 

_Have you run the entire test suite and no regression was detected?_

Yes