### PR TITLE
bugfix: without $self this is a function call, not a method call

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -868,7 +868,7 @@ sub print_status_and_return_reasons_to_exit {
         }
 
         if ($failed_job_count > 0) {
-           synchronize_AnalysisStats($stats);
+           $self->synchronize_AnalysisStats($stats);
            $stats->determine_status();
             my $exit_status;
             my $failure_message;


### PR DESCRIPTION
## Description

I've found this whilst working on a fix for negative job counts. `$self->` is missing here, which makes this line a _function_ call, not a _method_ call. The subroutine then gets `$stats` in `$self` and the other arguments (it expects `$stats` and `$has_refresh_just_been_done`) are both undefined.
Because it can deal with undefined `$stats` and returns immediately, it's never raised an error, but this means this call was doing nothing.

## Use case

I guess this only means that failures were not reported with the freshest stats, which people may not even notice.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes. OK