### PR TITLE
bugfix: oracle-java8 is not available any more, but openjdk-8 works

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,13 +35,9 @@ FROM ubuntu:16.04
 # Install git and java (taken from https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
-    && apt-get install -y git software-properties-common \
-    && (echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections) \
-    && add-apt-repository -y ppa:webupd8team/java \
-    && apt-get update -y \
-    && apt-get install -y oracle-java8-installer ant \
+    && apt-get install -y git software-properties-common openjdk-8-jdk ant \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/oracle-jdk8-installer
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Clone the repo
 RUN mkdir /repo && git clone -b version/2.5 https://github.com/Ensembl/ensembl-hive.git /repo/ensembl-hive
@@ -53,7 +49,6 @@ RUN /repo/ensembl-hive/docker/setup_os.Ubuntu-16.04.sh \
 ENV EHIVE_ROOT_DIR "/repo/ensembl-hive"
 ENV PATH "/repo/ensembl-hive/scripts:$PATH"
 ENV PERL5LIB "/repo/ensembl-hive/modules:$PERL5LIB"
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 ENTRYPOINT [ "/repo/ensembl-hive/scripts/dev/simple_init.py" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
## Use case

Docker builds have broken recently, because `apt` can't install the Oracle's Java version. See https://cloud.docker.com/u/ensemblorg/repository/registry-1.docker.io/ensemblorg/ensembl-hive/builds/6ade0715-5644-474d-8799-e157bdbac273

## Description

I've simply moved to openjdk. I can't remember why we needed oracle's version in the first place.

## Possible Drawbacks

If anything requires Oracle specifically, but @mira13 is also leaning towards openjdk in #104 

## Testing

_Have you added/modified unit tests to test the changes?_

I have rebuilt the Docker image locally and ran the example Java pipeline with ```prove -v /repo/ensembl-hive/t/10.pipeconfig/guest_language.t```

_If so, do the tests pass/fail?_

It worked

_Have you run the entire test suite and no regression was detected?_

Yes (within the Docker image)
