### PR TITLE
Tweak report during init_pipeline.pl

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
@@ -61,10 +61,9 @@ sub init_pipeline {
     $pipeconfig_object->add_objects_from_config( $pipeline );
 
     if($tweaks and @$tweaks) {
-        print "> Applying tweaks.\n";
+        print "> Applying tweaks.\n\n";
         my ($need_write, $msg_list_ref, $json) = $pipeline->apply_tweaks( $tweaks );
-        print join("", @$msg_list_ref);
-        print "\n";
+        $pipeconfig_object->print_debug(join("", @$msg_list_ref), "\n");
     }
 
     $pipeline->test_connections();

--- a/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
@@ -63,7 +63,7 @@ sub init_pipeline {
     if($tweaks and @$tweaks) {
         print "> Applying tweaks.\n";
         my ($need_write, $msg_list_ref, $json) = $pipeline->apply_tweaks( $tweaks );
-        print join("\n", $msg_list_ref);
+        print join("\n", @$msg_list_ref);
         print "\n";
     }
 

--- a/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
@@ -63,7 +63,7 @@ sub init_pipeline {
     if($tweaks and @$tweaks) {
         print "> Applying tweaks.\n";
         my ($need_write, $msg_list_ref, $json) = $pipeline->apply_tweaks( $tweaks );
-        print join("\n", @$msg_list_ref);
+        print join("", @$msg_list_ref);
         print "\n";
     }
 


### PR DESCRIPTION
## Use case

When initializing a pipeline with tweaks we currently see this:
```
$ init_pipeline.pl Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMultSt_javaconf $(mysql-local details hive) -tweak 'pipeline.param[take_time]=0'
(...)
> Applying tweaks.
ARRAY(0x2759b18)
> Storing the pipeline in the database.
(...)
```

1. We should be printing the actual tweaks, not a reference to a Perl array
2. The tweaks should only be displayed when `hive_debug_init` is set

## Description

The commits fix these two issues. Also, init_pipeline is now aware that the tweaks already contain `\n`, so no need to add it again.

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

No. The init_pipeline output is not covered by tests

_Have you run the entire test suite and no regression was detected?_

Yes - OK