### PR TITLE
standaloneJob for guest-languages

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
+++ b/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
@@ -525,7 +525,7 @@ sub life_cycle {
         input_job => {
             parameters => $job->{_unsubstituted_param_hash},
             input_id => $job->input_id,
-            dbID => $job->dbID + 0,
+            dbID => defined $job->dbID ? $job->dbID + 0 : 0,
             retry_count => $job->retry_count + 0,
         },
         execute_writes => $self->execute_writes || 0,

--- a/modules/Bio/EnsEMBL/Hive/Scripts/StandaloneJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/StandaloneJob.pm
@@ -59,7 +59,6 @@ sub standaloneJob {
         'logic_name'    => 'Standalone_Dummy_Analysis',     # looks nicer when printing out DFRs
         'module'        => $runnable_module,
         'language'      => $language,
-        'dbID'          => -1,
     );
 
     my $role = Bio::EnsEMBL::Hive::Role->new(
@@ -72,7 +71,6 @@ sub standaloneJob {
         'hive_pipeline' => $hive_pipeline,
         'analysis'      => $dummy_analysis,
         'input_id'      => $input_id,
-        'dbID'          => -1,
     );
 
     $worker->compile_runnable;

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -658,6 +658,12 @@ sub specialize_and_compile_wrapper {
     };
 
     if( !$self->cause_of_death() ) {
+        $self->compile_runnable;
+    }
+}
+
+sub compile_runnable {
+    my $self = shift;
         eval {
             $self->enter_status('COMPILATION');
 
@@ -675,7 +681,6 @@ sub specialize_and_compile_wrapper {
             my $last_err = $@;
             $self->handle_compilation_failure($last_err);
         };
-    }
 }
 
 sub handle_compilation_failure {

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -255,7 +255,7 @@ sub current_role {
         }
         my $new_role = shift @_;
         if( my $to_analysis = $new_role && $new_role->analysis ) {
-            $self->worker_say( "specializing to ".$to_analysis->logic_name.'('.$to_analysis->dbID.')' );
+            $self->worker_say( "specializing to ".$to_analysis->logic_name.'('.($to_analysis->dbID // 'unstored').')' );
         }
         $self->{'_current_role'} = $new_role;
     }

--- a/t/05.runnabledb/java.t
+++ b/t/05.runnabledb/java.t
@@ -1,0 +1,69 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Cwd            ();
+use File::Basename ();
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+use Test::More;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
+
+SKIP: {
+    skip "mvn not installed", 1 unless(`mvn -version 2>/dev/null`);
+
+plan tests => 1;
+
+standaloneJob(
+    'org.ensembl.hive.TestRunnable',
+    {
+        'alpha' => 2,
+    },
+    [
+        [
+            'WARNING',
+            'Fetch the world !',
+            'INFO',
+        ], [
+            'WARNING',
+            'Run the world !',
+            'INFO',
+        ], [
+            'WARNING',
+            'Write to the world !',
+            'INFO',
+        ], [
+            'DATAFLOW',
+            [{
+                'gamma' => 80,
+            }],
+            2
+        ]
+    ],
+    {
+        'language'  => 'java',
+    },
+);
+
+} # /SKIP
+
+done_testing();
+

--- a/wrappers/java/src/main/java/org/ensembl/hive/TestRunnable.java
+++ b/wrappers/java/src/main/java/org/ensembl/hive/TestRunnable.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ * Copyright [2016-2019] EMBL-European Bioinformatics Institute
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ensembl.hive;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.ensembl.hive.BaseRunnable;
+import org.ensembl.hive.Job;
+import org.slf4j.LoggerFactory;
+
+public class TestRunnable extends BaseRunnable {
+
+	public static final String ALPHA = "alpha";
+	public static final String BETA = "beta";
+	public static final String GAMMA = "gamma";
+
+	@Override
+	protected Map<String, Object> getParamDefaults() {
+		return toMap(
+		         ALPHA, 37,
+		         BETA, 78
+		       );
+	}
+
+	@Override
+	protected void fetchInput(Job job) {
+		warning("Fetch the world !", false);
+		getLog().info("alpha is", job.paramRequired(ALPHA));
+		getLog().info("beta is", job.paramRequired(BETA));
+	}
+
+	@Override
+	protected void run(Job job) {
+		warning("Run the world !", false);
+		long s = numericParamToLong(job.getParameters().getParam(ALPHA)) + numericParamToLong(job.getParameters().getParam(BETA));
+		getLog().info("set gamma to", s);
+		job.getParameters().setParam(GAMMA, s);
+	}
+
+	@Override
+	protected void writeOutput(Job job) {
+		warning("Write to the world !", false);
+		getLog().info("gamma is", job.paramRequired(GAMMA));
+		dataflow(job.getParameters(), Arrays.asList(toMap("gamma", job.getParameters().getParam(GAMMA))), 2);
+	}
+}


### PR DESCRIPTION
## Use case

I found his bug when testing #104 
```standaloneJob.pl org.ensembl.hive.longmult.DigitFactory -language java -a_multiplier 1234 -b_multiplier 4567 -debug 1```
doesn't work unless you have manually compiled the Java code. The compilation only happens automatically when running init_pipeline.pl or runWorker.pl

## Description

I'm making standaloneJob even closer to runWorker by asking the Worker itself to compile the module (after creating a Role that links the Worker to the Analysis), like in the other parts of eHive.

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

I will add a test soon

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
