### PR TITLE
Experimental/worker temp dir

### DIFF
--- a/docs/advanced_usage/mpi.rst
+++ b/docs/advanced_usage/mpi.rst
@@ -204,16 +204,9 @@ In our case, Examl uses MPI and wants to share data via the filesystem too.
 In this specific Runnable, Examl is set to run in eHive's managed temporary
 directory, which by default is under /tmp which is not shared across nodes on
 our compute cluster.
-We have to override the eHive method to use a shared directory (``$self->param('examl_dir')``) instead.
+We have to override the eHive method to use a shared directory (``$self->o('examl_dir')``) instead.
 
-::
-
-      use Path::Tiny;
-
-      sub worker_temp_directory_name {
-          my $self = shift @_;
-          my $default_temp_directory_name = $self->SUPER::worker_temp_directory_name(@_);
-          my $name = path($default_temp_directory_name)->basename;
-          return $self->param('examl_dir')."/$name/";
-      }
+This can be done at the resource class level, by adding
+``"-worker_base_tmp_dir ".$self->o('examl_dir')`` to the
+``worker_cmd_args`` attribute of the resource-class
 

--- a/docs/creating_runnables/runnable_api.rst
+++ b/docs/creating_runnables/runnable_api.rst
@@ -84,7 +84,8 @@ Job (by removing some files, for instance), or to clean it up completely
 with ``$self->cleanup_worker_temp_directory``.
 
 By default, this directory will be put under /tmp, but it can be overriden
-by adding a ``worker_temp_directory_name`` method to the runnable. This can
+by setting the ``-worker_base_tmp_dir`` option for workers through their
+resource classes. This can
 be used to:
 
 - use a faster filesystem (although /tmp is usually local to the machine),

--- a/hive_config.json
+++ b/hive_config.json
@@ -9,7 +9,7 @@
     "Meadow" : {
         "REMARKS" : {
             "HOWTO"             : "These parameters are optional. When setting them, move them out of the REMARKS section at the same time",
-            "BaseTempDirectory" : "Where to create temporary directories for workers. When null or missing, workers will use /tmp",
+            "BaseTempDirectory" : "Where to create temporary directories for workers. When null or missing, workers will ask File::Spec, which choses $TMPDIR or /tmp",
             "RunWorkerPath"     : "The path of runWorker.pl . When null or missing, beekeeper will use $EHIVE_ROOT_DIR or its own path. When RunWorkerPath is '', beekeeper assumes runWorker.pl is in $PATH"
         },
         "CleanupTempDirectoryKilledWorkers" : 0,

--- a/hive_config.json
+++ b/hive_config.json
@@ -8,7 +8,9 @@
     },
     "Meadow" : {
         "REMARKS" : {
-            "RunWorkerPath" : "The path of runWorker.pl . When null or missing, beekeeper will use $EHIVE_ROOT_DIR or its own path. When RunWorkerPath is '', beekeeper assumes runWorker.pl is in $PATH"
+            "HOWTO"             : "These parameters are optional. When setting them, move them out of the REMARKS section at the same time",
+            "BaseTempDirectory" : "Where to create temporary directories for workers. When null or missing, workers will use /tmp",
+            "RunWorkerPath"     : "The path of runWorker.pl . When null or missing, beekeeper will use $EHIVE_ROOT_DIR or its own path. When RunWorkerPath is '', beekeeper assumes runWorker.pl is in $PATH"
         },
         "CleanupTempDirectoryKilledWorkers" : 0,
         "MaxLimboSeconds"                   : 10,

--- a/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
+++ b/modules/Bio/EnsEMBL/Hive/GuestProcess.pm
@@ -79,7 +79,7 @@ response from GuestProcess):
     ---> dbIDs of the jobs that have been created
 
     <--- WORKER_TEMP_DIRECTORY
-         // The content is the "worker_temp_directory_name" as defined in the runnable (or null otherwise)
+         // No content needed (ignored)
     ---> returns the temporary directory of the worker
 
     <--- JOB_END
@@ -135,7 +135,7 @@ use base ('Bio::EnsEMBL::Hive::Process');
 
 # -------------------------------------- <versioning of the GuestProcess interface> -------------------------------------------------------
 
-our $GUESTPROCESS_PROTOCOL_VERSION = '3';       # Make sure you change this number whenever an incompatible change is introduced
+our $GUESTPROCESS_PROTOCOL_VERSION = '4';       # Make sure you change this number whenever an incompatible change is introduced
 
 
 =head2 get_protocol_version
@@ -561,7 +561,6 @@ sub life_cycle {
             $self->send_response($d);
 
         } elsif ($event eq 'WORKER_TEMP_DIRECTORY') {
-            $self->{worker_temp_directory_name} = $content;
             my $wtd = $self->worker_temp_directory;
             $self->send_response($wtd);
 
@@ -598,33 +597,12 @@ sub life_cycle {
     }
 }
 
-=head2 worker_temp_directory_name
-
-  Example     : $process->worker_temp_directory_name();
-  Description : Returns the name of the temp directory for this module
-                The value in $self is initialized at the WORKER_TEMP_DIRECTORY
-                event above and returned to the caller if defined. This allows
-                runnables to redefine the name
-  Returntype  : string
-  Exceptions  : none
-
-=cut
-
-sub worker_temp_directory_name {
-    my $self = shift;
-    return $self->{worker_temp_directory_name} if $self->{worker_temp_directory_name};
-    return $self->SUPER::worker_temp_directory_name();
-}
-
-
-
 
 ### Summary of Process methods ###
 
 ## Have to be redefined
 # life_cycle
 # param_defaults
-# worker_temp_directory_name
 
 ## Needed, can be reused from the base class
 # worker_temp_directory

--- a/modules/Bio/EnsEMBL/Hive/Meadow.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow.pm
@@ -414,4 +414,23 @@ sub run_on_host {
     return system('timeout', '3m', 'ssh', @extra_args, '-o', 'BatchMode=yes', '-o', 'ServerAliveInterval=30', sprintf('%s@%s', $meadow_user, $meadow_host), @$command);
 }
 
+
+=head2 cleanup_temp_directory
+
+    Title   :  cleanup_temp_directory
+    Function:  Cleanup the temp directory assigned to the worker
+
+=cut
+
+sub cleanup_temp_directory {
+    my ($self, $worker) = @_;
+
+    # The feature can be disabled for this actual meadow
+    return unless $self->config_get('CleanupTempDirectoryKilledWorkers');
+
+    print "GarbageCollector:\tCleaning-up ".$worker->temp_directory_name."\n";
+    my $rc = $self->run_on_host($worker->meadow_host, $worker->meadow_user, ['rm', '-rf', $worker->temp_directory_name]);
+    $worker->worker_say(sprintf("Error: could not clean %s's temp directory '%s': %s\n", $worker->meadow_host, $worker->temp_directory_name, $@)) if $rc;
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -101,7 +101,7 @@ package Bio::EnsEMBL::Hive::Process;
 use strict;
 use warnings;
 
-use File::Path qw(remove_tree);
+use File::Path qw(make_path remove_tree);
 use JSON;
 use Scalar::Util qw(looks_like_number);
 use Time::HiRes qw(time);
@@ -679,7 +679,7 @@ sub worker_temp_directory {
 
     unless(defined($self->{'_tmp_dir'}) and (-e $self->{'_tmp_dir'})) {
         $self->{'_tmp_dir'} = $self->worker_temp_directory_name();
-        mkdir($self->{'_tmp_dir'}, 0777);
+        make_path( $self->{'_tmp_dir'}, { mode => 0777 } );
         throw("unable to create a writable directory ".$self->{'_tmp_dir'}) unless(-w $self->{'_tmp_dir'});
     }
     return $self->{'_tmp_dir'};

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -678,17 +678,11 @@ sub worker_temp_directory {
     my $self = shift @_;
 
     unless(defined($self->{'_tmp_dir'}) and (-e $self->{'_tmp_dir'})) {
-        $self->{'_tmp_dir'} = $self->worker_temp_directory_name();
+        $self->{'_tmp_dir'} = $self->worker->temp_directory_name();
         make_path( $self->{'_tmp_dir'}, { mode => 0777 } );
         throw("unable to create a writable directory ".$self->{'_tmp_dir'}) unless(-w $self->{'_tmp_dir'});
     }
     return $self->{'_tmp_dir'};
-}
-
-sub worker_temp_directory_name {
-    my $self = shift @_;
-
-    return $self->worker->temp_directory_name;
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -704,9 +704,8 @@ sub worker_temp_directory_name {
 sub cleanup_worker_temp_directory {
     my $self = shift @_;
 
-    my $tmp_dir = $self->worker_temp_directory_name();
-    if(-e $tmp_dir) {
-        remove_tree($tmp_dir, {error => undef});
+    if(defined($self->{'_tmp_dir'}) and (-e $self->{'_tmp_dir'})) {
+        remove_tree($self->{'_tmp_dir'}, {error => undef});
     }
 }
 

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -572,7 +572,6 @@ sub check_for_dead_workers {    # scans the whole Valley for lost Workers (but i
 
                     if( ($worker->status ne 'SUBMITTED')                 # There is no worker_temp_directory before specialization
                     and ($worker->meadow_user eq $this_meadow_user) ) {  # if I'm actually allowed to kill the worker...
-                            $worker->set_temp_directory_name( $this_meadow->config_get('BaseTempDirectory') );
                             $this_meadow->cleanup_temp_directory( $worker );
                     }
                 }

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -222,7 +222,7 @@ sub create_new_worker {
     }
 
     $worker->set_log_directory_name($hive_log_dir, $worker_log_dir);
-    $worker->set_temp_directory_name( $worker_base_temp_dir );
+    $worker->set_temp_directory_name( $worker_base_temp_dir || $meadow->config_get('BaseTempDirectory') );
 
     $worker->init;
 
@@ -572,6 +572,7 @@ sub check_for_dead_workers {    # scans the whole Valley for lost Workers (but i
 
                     if( ($worker->status ne 'SUBMITTED')                 # There is no worker_temp_directory before specialization
                     and ($worker->meadow_user eq $this_meadow_user) ) {  # if I'm actually allowed to kill the worker...
+                            $worker->set_temp_directory_name( $this_meadow->config_get('BaseTempDirectory') );
                             $this_meadow->cleanup_temp_directory( $worker );
                     }
                 }

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -571,7 +571,7 @@ sub check_for_dead_workers {    # scans the whole Valley for lost Workers (but i
 
                     if( ($worker->status ne 'SUBMITTED')                 # There is no worker_temp_directory before specialization
                     and ($worker->meadow_user eq $this_meadow_user) ) {  # if I'm actually allowed to kill the worker...
-                            $valley->cleanup_left_temp_directory( $worker );
+                            $this_meadow->cleanup_temp_directory( $worker );
                     }
                 }
             }

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -128,10 +128,10 @@ sub create_new_worker {
     my %flags   = @_;
 
     my ($preregistered, $resource_class_id, $resource_class_name, $beekeeper_id,
-            $no_write, $debug, $worker_log_dir, $hive_log_dir, $job_limit, $life_span, $no_cleanup, $retry_throwing_jobs, $can_respecialize,
+            $no_write, $debug, $worker_base_temp_dir, $worker_log_dir, $hive_log_dir, $job_limit, $life_span, $no_cleanup, $retry_throwing_jobs, $can_respecialize,
             $worker_delay_startup_seconds, $worker_crash_on_startup_prob, $config_files)
      = @flags{qw(-preregistered -resource_class_id -resource_class_name -beekeeper_id
-            -no_write -debug -worker_log_dir -hive_log_dir -job_limit -life_span -no_cleanup -retry_throwing_jobs -can_respecialize
+            -no_write -debug -worker_base_temp_dir -worker_log_dir -hive_log_dir -job_limit -life_span -no_cleanup -retry_throwing_jobs -can_respecialize
             -worker_delay_startup_seconds -worker_crash_on_startup_prob -config_files)};
 
     sleep( $worker_delay_startup_seconds // 0 );    # NB: undefined parameter would have caused eternal sleep!
@@ -222,6 +222,7 @@ sub create_new_worker {
     }
 
     $worker->set_log_directory_name($hive_log_dir, $worker_log_dir);
+    $worker->set_temp_directory_name( $worker_base_temp_dir );
 
     $worker->init;
 

--- a/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm
@@ -58,6 +58,7 @@ sub runWorker {
              -life_span             => $life_options->{'life_span'},
              -no_cleanup            => $execution_options->{'no_cleanup'},
              -no_write              => $execution_options->{'no_write'},
+             -worker_base_temp_dir  => $execution_options->{'worker_base_temp_dir'},
              -worker_log_dir        => $execution_options->{'worker_log_dir'},
              -hive_log_dir          => $execution_options->{'hive_log_dir'},
              -retry_throwing_jobs   => $life_options->{'retry_throwing_jobs'},

--- a/modules/Bio/EnsEMBL/Hive/Valley.pm
+++ b/modules/Bio/EnsEMBL/Hive/Valley.pm
@@ -247,20 +247,4 @@ sub status_of_all_our_workers_by_meadow_signature {
 }
 
 
-sub cleanup_left_temp_directory {
-    my ($self, $worker) = @_;
-
-    # cleanup_left_temp_directory is called when garbage-collecting dead-workers,
-    # which is only possible for reachable meadows.
-    # This guarantees that $meadow is defined.
-    my $meadow = $self->available_meadow_hash->{$worker->meadow_type};
-
-    if ($meadow->config_get('CleanupTempDirectoryKilledWorkers')) {
-        print "GarbageCollector:\tCleaning-up /tmp\n";
-        my $rc = $meadow->run_on_host($worker->meadow_host, $worker->meadow_user, ['rm', '-rf', $worker->temp_directory_name]);
-        $worker->worker_say(sprintf("Error: could not clean %s's temp directory '%s': %s\n", $worker->meadow_host, $worker->temp_directory_name, $@)) if $rc;
-    }
-}
-
-
 1;

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -947,6 +947,7 @@ sub set_temp_directory_name {
     }
 
     $self->temp_directory_name( $temp_directory_name );
+    $self->adaptor->update_temp_directory_name( $self ) if $self->adaptor;  # autoloaded
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -243,6 +243,23 @@ sub log_dir {
 }
 
 
+=head2 temp_directory_name
+
+  Arg [1] : (optional) string directory path
+  Title   : temp_directory_name
+  Usage   : $worker_tmp_dir = $self->temp_directory_name;
+            $self->temp_directory_name($worker_tmp_dir);
+  Description: Storable getter/setter attribute for the directory where jobs can store temporary data.
+  Returntype : string
+
+=cut
+
+sub temp_directory_name {
+    my $self = shift;
+    $self->{'_tmp_dir'} = shift if(@_);
+    return $self->{'_tmp_dir'};
+}
+
 
 ## Non-Storable attributes:
 
@@ -906,14 +923,28 @@ sub set_log_directory_name {
 }
 
 
-sub temp_directory_name {
-    my $self = shift @_;
+=head2 set_temp_directory_name
 
+  Title       : set_temp_directory_name
+  Description : Generates and sets the name of a temporary directory suitable for this worker.
+                It will be under the base directory requested by $base_temp_dir, or /tmp
+                otherwise, and includes worker attributes to make the path unique.
+
+=cut
+
+sub set_temp_directory_name {
+    my ($self, $base_temp_dir) = @_;
+
+    $base_temp_dir //= '/tmp';
+
+    my $temp_directory_name;
     if ($self->adaptor) {
-        return sprintf('/tmp/worker_%s_%s.%s/', $self->meadow_user, $self->hive_pipeline->hive_pipeline_name, $self->dbID);
+        $temp_directory_name = sprintf('%s/worker_%s_%s.%s/', $base_temp_dir, $self->meadow_user, $self->hive_pipeline->hive_pipeline_name, $self->dbID);
     } else {
-        return sprintf('/tmp/worker_%s.standalone.%s/', $self->meadow_user, $self->process_id);
+        $temp_directory_name = sprintf('%s/worker_%s.standalone.%s/', $base_temp_dir, $self->meadow_user, $self->process_id);
     }
+
+    $self->temp_directory_name( $temp_directory_name );
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -76,6 +76,7 @@ use strict;
 use warnings;
 use POSIX;
 use File::Path 'make_path';
+use File::Spec;
 
 use Bio::EnsEMBL::Hive::AnalysisStats;
 use Bio::EnsEMBL::Hive::Limiter;
@@ -927,15 +928,16 @@ sub set_log_directory_name {
 
   Title       : set_temp_directory_name
   Description : Generates and sets the name of a temporary directory suitable for this worker.
-                It will be under the base directory requested by $base_temp_dir, or /tmp
-                otherwise, and includes worker attributes to make the path unique.
+                It will be under the base directory requested by $base_temp_dir, or the standard
+                location otherwise (as advised by File::Spec), and includes worker attributes
+                to make the path unique.
 
 =cut
 
 sub set_temp_directory_name {
     my ($self, $base_temp_dir) = @_;
 
-    $base_temp_dir //= '/tmp';
+    $base_temp_dir //= File::Spec->tmpdir();
 
     my $temp_directory_name;
     if ($self->adaptor) {

--- a/scripts/runWorker.pl
+++ b/scripts/runWorker.pl
@@ -27,7 +27,7 @@ main();
 sub main {
     my ($url, $reg_conf, $reg_type, $reg_alias, $nosqlvc);                   # Connection parameters
     my ($preregistered, $resource_class_id, $resource_class_name, $analyses_pattern, $analysis_id, $logic_name, $job_id, $force, $beekeeper_id);    # Task specification parameters
-    my ($job_limit, $life_span, $no_cleanup, $no_write, $worker_cur_dir, $hive_log_dir, $worker_log_dir, $retry_throwing_jobs, $can_respecialize,   # Worker control parameters
+    my ($job_limit, $life_span, $no_cleanup, $no_write, $worker_cur_dir, $hive_log_dir, $worker_log_dir, $worker_base_temp_dir, $retry_throwing_jobs, $can_respecialize,   # Worker control parameters
         $worker_delay_startup_seconds, $worker_crash_on_startup_prob, $config_files);
     my ($help, $report_versions, $debug);
 
@@ -67,6 +67,7 @@ sub main {
                'worker_cur_dir|cwd=s'       => \$worker_cur_dir,
                'hive_log_dir|hive_output_dir=s'         => \$hive_log_dir,       # keep compatibility with the old name
                'worker_log_dir|worker_output_dir=s'     => \$worker_log_dir,     # will take precedence over hive_log_dir if set
+               'worker_base_temp_dir=s'     => \$worker_base_temp_dir,
                'retry_throwing_jobs!'       => \$retry_throwing_jobs,
                'can_respecialize|can_respecialise!' => \$can_respecialize,
                'worker_delay_startup_seconds=i' => \$worker_delay_startup_seconds,
@@ -143,6 +144,7 @@ sub main {
         config_files        => $config_files,
         no_cleanup          => $no_cleanup,
         no_write            => $no_write,
+        worker_base_temp_dir=> $worker_base_temp_dir,
         worker_log_dir      => $worker_log_dir,
         hive_log_dir        => $hive_log_dir,
         debug               => $debug,
@@ -272,6 +274,11 @@ don't perform temp directory cleanup when the Worker exits
 =item --no_write
 
 don't write_output or auto_dataflow input_job
+
+=item --worker_base_temp_dir <path>
+
+The base directory that this worker will use for temporary operations. This overrides the default set
+in the JSON config file and in the code (/tmp)
 
 =item --hive_log_dir <path>
 

--- a/sql/patch_2019-05-10.mysql
+++ b/sql/patch_2019-05-10.mysql
@@ -1,0 +1,52 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- ---------------------------------------------------------------------------------------------------
+
+SET @expected_version = 95;
+
+    -- make MySQL stop immediately after it encounters division by zero:
+SET SESSION sql_mode='TRADITIONAL';
+
+    -- warn that we detected the schema version mismatch:
+SELECT CONCAT(  'The patch only applies to schema version ',
+                @expected_version,
+                ', but the current schema version is ',
+                meta_value,
+                ', so skipping the rest.') AS ''
+    FROM hive_meta WHERE meta_key='hive_sql_schema_version' AND meta_value<>@expected_version;
+
+    -- cause division by zero only if current version differs from the expected one:
+INSERT INTO hive_meta (meta_key, meta_value)
+    SELECT 'this_should_never_be_inserted', 1 FROM hive_meta WHERE NOT 1/(meta_key<>'hive_sql_schema_version' OR meta_value=@expected_version);
+
+SELECT CONCAT(  'The patch seems to be compatible with schema version ',
+                @expected_version,
+                ', applying the patch...') AS '';
+
+    -- Now undo the change so that we could patch potentially non-TRADITIONAL schema:
+SET SESSION sql_mode='';
+
+-- ----------------------------------<actual_patch> -------------------------------------------------
+
+ALTER TABLE worker ADD COLUMN temp_directory_name VARCHAR(255) AFTER cause_of_death;
+
+-- ----------------------------------</actual_patch> -------------------------------------------------
+
+
+    -- increase the schema version by one and register the patch:
+UPDATE hive_meta SET meta_value=meta_value+1 WHERE meta_key='hive_sql_schema_version';
+INSERT INTO hive_meta (meta_key, meta_value) SELECT CONCAT("patched_to_", meta_value), CURRENT_TIMESTAMP FROM hive_meta WHERE meta_key = "hive_sql_schema_version";

--- a/sql/patch_2019-05-10.pgsql
+++ b/sql/patch_2019-05-10.pgsql
@@ -1,0 +1,49 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- ---------------------------------------------------------------------------------------------------
+
+\set expected_version 95
+
+\set ON_ERROR_STOP on
+
+    -- warn that we detected the schema version mismatch:
+SELECT ('The patch only applies to schema version '
+    || CAST(:expected_version AS VARCHAR)
+    || ', but the current schema version is '
+    || meta_value
+    || ', so skipping the rest.') as incompatible_msg
+    FROM hive_meta WHERE meta_key='hive_sql_schema_version' AND meta_value!=CAST(:expected_version AS VARCHAR);
+
+    -- cause division by zero only if current version differs from the expected one:
+INSERT INTO hive_meta (meta_key, meta_value)
+   SELECT 'this_should_never_be_inserted', 1 FROM hive_meta WHERE 1 != 1/CAST( (meta_key!='hive_sql_schema_version' OR meta_value=CAST(:expected_version AS VARCHAR)) AS INTEGER );
+
+SELECT ('The patch seems to be compatible with schema version '
+    || CAST(:expected_version AS VARCHAR)
+    || ', applying the patch...') AS compatible_msg;
+
+
+-- ----------------------------------<actual_patch> -------------------------------------------------
+
+ALTER TABLE worker ADD COLUMN temp_directory_name VARCHAR(255) DEFAULT NULL;
+
+-- ----------------------------------</actual_patch> -------------------------------------------------
+
+
+    -- increase the schema version by one and register the patch:
+UPDATE hive_meta SET meta_value= (CAST(meta_value AS INTEGER) + 1) WHERE meta_key='hive_sql_schema_version';
+INSERT INTO hive_meta (meta_key, meta_value) SELECT 'patched_to_' || meta_value, CURRENT_TIMESTAMP FROM hive_meta WHERE meta_key = 'hive_sql_schema_version';

--- a/sql/tables.mysql
+++ b/sql/tables.mysql
@@ -497,6 +497,7 @@ CREATE TABLE analysis_data (
 @column when_seen           when the Worker was last seen by the Meadow
 @column when_died           if defined, when the Worker died (or its premature death was first detected by GC)
 @column cause_of_death      if defined, why did the Worker exit (or why it was killed)
+@column temp_directory_name a filesystem directory where this Worker can store temporary data
 @column log_dir             if defined, a filesystem directory where this Worker's output is logged
 */
 
@@ -518,6 +519,7 @@ CREATE TABLE worker (
     when_seen               TIMESTAMP                    NULL,
     when_died               TIMESTAMP                    NULL,      -- mysql's special for "TIMESTAMP DEFAULT NULL"
     cause_of_death          VARCHAR(255)         DEFAULT NULL,      -- expected values: 'NO_ROLE', 'NO_WORK', 'JOB_LIMIT', 'HIVE_OVERLOAD', 'LIFESPAN', 'CONTAMINATED', 'RELOCATED', 'KILLED_BY_USER', 'MEMLIMIT', 'RUNLIMIT', 'SEE_MSG', 'LIMBO', 'UNKNOWN'
+    temp_directory_name     VARCHAR(255)         DEFAULT NULL,
     log_dir                 VARCHAR(255)         DEFAULT NULL,
 
     KEY meadow_process (meadow_type, meadow_name, process_id)

--- a/sql/tables.pgsql
+++ b/sql/tables.pgsql
@@ -509,6 +509,7 @@ CREATE INDEX ON analysis_data (md5sum);
 @column when_seen           when the Worker was last seen by the Meadow
 @column when_died           if defined, when the Worker died (or its premature death was first detected by GC)
 @column cause_of_death      if defined, why did the Worker exit (or why it was killed)
+@column temp_directory_name a filesystem directory where this Worker can store temporary data
 @column log_dir             if defined, a filesystem directory where this Worker's output is logged
 */
 
@@ -529,6 +530,7 @@ CREATE TABLE worker (
     when_seen               TIMESTAMP            DEFAULT NULL,
     when_died               TIMESTAMP            DEFAULT NULL,
     cause_of_death          VARCHAR(255)         DEFAULT NULL,      -- expected values: 'NO_ROLE', 'NO_WORK', 'JOB_LIMIT', 'HIVE_OVERLOAD', 'LIFESPAN', 'CONTAMINATED', 'RELOCATED', 'KILLED_BY_USER', 'MEMLIMIT', 'RUNLIMIT', 'SEE_MSG', 'LIMBO', 'UNKNOWN'
+    temp_directory_name     VARCHAR(255)         DEFAULT NULL,
     log_dir                 VARCHAR(255)         DEFAULT NULL
 );
 CREATE INDEX ON worker (meadow_type, meadow_name, process_id);

--- a/sql/tables.sqlite
+++ b/sql/tables.sqlite
@@ -490,6 +490,7 @@ CREATE        INDEX analysis_data_idx ON analysis_data (md5sum);
 @column when_seen           when the Worker was last seen by the Meadow
 @column when_died           if defined, when the Worker died (or its premature death was first detected by GC)
 @column cause_of_death      if defined, why did the Worker exit (or why it was killed)
+@column temp_directory_name a filesystem directory where this Worker can store temporary data
 @column log_dir             if defined, a filesystem directory where this Worker's output is logged
 */
 
@@ -511,6 +512,7 @@ CREATE TABLE worker (
     when_seen               TIMESTAMP            DEFAULT NULL,
     when_died               TIMESTAMP            DEFAULT NULL,
     cause_of_death          VARCHAR(255)         DEFAULT NULL, /* enum('NO_ROLE', 'NO_WORK', 'JOB_LIMIT', 'HIVE_OVERLOAD', 'LIFESPAN', 'CONTAMINATED', 'RELOCATED', 'KILLED_BY_USER', 'MEMLIMIT', 'RUNLIMIT', 'SEE_MSG', 'LIMBO', 'UNKNOWN') DEFAULT NULL */
+    temp_directory_name     VARCHAR(255)         DEFAULT NULL,
     log_dir                 VARCHAR(255)         DEFAULT NULL
 );
 CREATE INDEX worker_meadow_type_meadow_name_process_id_idx ON worker (meadow_type, meadow_name, process_id);

--- a/t/03.scripts/runWorker.t
+++ b/t/03.scripts/runWorker.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use File::Temp qw{tempdir};
+use Test::Exception;
+use Test::More;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline get_test_url_or_die runWorker safe_drop_database);
+
+# eHive needs this to initialize the pipeline (and run db_cmd.pl)
+use Cwd            ();
+use File::Basename ();
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+my $pipeline_url = get_test_url_or_die;
+
+init_pipeline(
+    'Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMult_conf',
+    $pipeline_url,
+    [],
+    ['pipeline.param[take_time]=0', 'analysis[take_b_apart].meadow_type=undef', 'analysis[take_b_apart].analysis_capacity=1'],
+);
+
+my $dir = tempdir CLEANUP => 1;
+
+runWorker($pipeline_url, [ -job_id => 1, ]);
+runWorker($pipeline_url, [ -job_id => 2, -worker_base_temp_dir => $dir ]);
+
+my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+
+my $worker1 = $hive_dba->get_WorkerAdaptor->fetch_by_dbID(1);
+my $worker2 = $hive_dba->get_WorkerAdaptor->fetch_by_dbID(2);
+
+unlike($worker1->temp_directory_name, qr{^$dir}, "The first worker is not using $dir");
+  like($worker2->temp_directory_name, qr{^$dir}, "The second worker used $dir");
+
+safe_drop_database( $hive_dba );
+
+done_testing();
+

--- a/wrappers/java/build.xml
+++ b/wrappers/java/build.xml
@@ -8,7 +8,7 @@
 	<property name="build" location="build" />
 	<property name="lib" location="lib" />
 	<property name="doc" location="doc" />
-	<property name="version" value="3.1" />
+	<property name="version" value="4.0" />
 
 	<path id="wrapper_classpath">
 		<fileset dir="${lib}/">

--- a/wrappers/java/src/org/ensembl/hive/BaseRunnable.java
+++ b/wrappers/java/src/org/ensembl/hive/BaseRunnable.java
@@ -73,7 +73,7 @@ public abstract class BaseRunnable {
 	private static final String JOB_END_TYPE = "JOB_END";
 	private static final String OK = "OK";
 
-	public final static String VERSION = "3.1";
+	public final static String VERSION = "4.0";
 
 	protected final static Map<String, Object> DEFAULT_PARAMS = new HashMap<>();
 
@@ -317,21 +317,11 @@ public abstract class BaseRunnable {
 	 */
 	protected String workerTempDirectory() {
 		if (workerTempDirectory == null) {
-			sendEventMessage(WORKER_TEMP_DIRECTORY_TYPE,
-					getWorkerTemplateName());
+			sendEventMessage(WORKER_TEMP_DIRECTORY_TYPE, null);
 			workerTempDirectory = (String) (readMessageAndRespond()
 					.get(RESPONSE_KEY));
 		}
 		return workerTempDirectory;
-	}
-
-	/**
-	 * Override to provide a special template for the worker temporary directory
-	 * 
-	 * @return A String representing the template location for worker directories or null
-	 */
-	protected String getWorkerTemplateName() {
-		return null;
 	}
 
 	/**

--- a/wrappers/python3/eHive/Process.py
+++ b/wrappers/python3/eHive/Process.py
@@ -24,7 +24,7 @@ import unittest
 import warnings
 import traceback
 
-__version__ = "3.0"
+__version__ = "4.0"
 
 __doc__ = """
 This module mainly implements python's counterpart of GuestProcess. Read
@@ -219,12 +219,9 @@ class BaseRunnable(object):
 
     def worker_temp_directory(self):
         """Returns the full path of the temporary directory created by the worker.
-        Runnables can implement "worker_temp_directory_name()" to return the name
-        they would like to use
         """
         if self.__created_worker_temp_directory is None:
-            template_name = self.worker_temp_directory_name() if hasattr(self, 'worker_temp_directory_name') else None
-            self.__send_message('WORKER_TEMP_DIRECTORY', template_name)
+            self.__send_message('WORKER_TEMP_DIRECTORY', None)
             self.__created_worker_temp_directory = self.__read_message()['response']
         return self.__created_worker_temp_directory
 

--- a/wrappers/python3/eHive/examples/TestRunnable.py
+++ b/wrappers/python3/eHive/examples/TestRunnable.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# standaloneJob.pl eHive.examples.TestRunnable -language python3
+
+import os
+import subprocess
+
 import eHive
 
 class TestRunnable(eHive.BaseRunnable):
@@ -29,15 +34,20 @@ class TestRunnable(eHive.BaseRunnable):
         self.warning("Fetch the world !")
         print("alpha is", self.param_required('alpha'))
         print("beta is", self.param_required('beta'))
+        self.temp_dir = self.worker_temp_directory()
+        print("my directory name is", self.temp_dir)
 
     def run(self):
         self.warning("Run the world !")
         s = self.param('alpha') + self.param('beta')
         print("set gamma to", s)
         self.param('gamma', s)
+        self.greeting_path = os.path.join(self.temp_dir, "hello")
+        subprocess.check_call(["touch", self.greeting_path])
 
     def write_output(self):
         self.warning("Write to the world !")
         print("gamma is", self.param('gamma'))
         self.dataflow( {'gamma': self.param('gamma')}, 2 )
+        print("Greetings in place:", os.path.exists(self.greeting_path))
 


### PR DESCRIPTION
## Use case

This addresses issues encountered by various teams recently regarding the temporary space allocated on the EBI farm. `/tmp` is smaller than what it used to be, `/scratch` is the advised replacement of `/tmp/`, and teams sometimes need a much bigger space or a shared space. Overall, this demonstrates a need to configure the default temporary directory used by Workers.

## Description

Here I introduce a new command-line option for workers: `worker_base_temp_dir` (like `worker_log_dir`) to change what to use instead of /tmp. Command-line options can be set at the resource-class level, so the option can easily be applied to an analysis. A global default can also be set in the JSON configuration file.

I have removed the possibility of defining the temp directory name in the Runnable itself. If Runnables want to use a specific path, they would have to directly use the path they want, or instead override `worker_temp_directory` (I would advise the former). Anyway, the only Runnables that were doing that are in Compara, as far as I could see, and I'll update them. Note that this causes a breaking change to the GuestLanguage interface, which I fix here too.

I have introduced a new column in the `worker` table to track the temp directory actually used, which allows beekeeper to properly clean up leftover data from killed workers (during the garbage collection). I have also moved that function from Valley to Meadow because the meadow is known at that point and there is no need to query the Valley.

## Possible Drawbacks

External users that have their own GuestLanguage wrappers will have to update those.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes

## Comments

As I will be away for the next three weeks, I won't be able to follow up with your review immediately. I still wanted to open a PR to give time to review the code and start discussing the changes. If you think it is appropriate, you can also tell the eHive reps about this branch as they may want to give it a try too.
Finally, feel free to modify the branch yourselves if you want to quickly merge this feature.