### PR TITLE
Feature/open jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,17 @@ before_install:
     - export PATH=$PWD:$PATH
     - mkdir deps
     - ln -s /usr/share/perl5/PgCommon.pm deps/
+    - export EHIVE_HOME=$PWD
+    - cd ../
+    - wget https://download.java.net/java/early_access/jdk13/21/GPL/openjdk-13-ea+21_linux-x64_bin.tar.gz
+    - tar xvzf openjdk-13-ea+21_linux-x64_bin.tar.gz
+    - export JAVA_HOME=$PWD/jdk-13
+    - export PATH=$JAVA_HOME/bin:$PATH
+    - export JAVA_JRE=$JAVA_HOME
+    - cd $EHIVE_HOME
+    - ls $JAVA_HOME
     - java -version
+    - javac -version
     - mvn -version
     - mysql --version
     - sqlite3 --version
@@ -65,4 +75,3 @@ notifications:
       # ehive-commits
       - secure: XUShBwss607RlWDQyn4tkVDX390+aIXv1ntaUzr9MtsXMpCNm5X/7PPle7Cq6FZ57vHzkIOM0+FM3kIou7vbc3ediwHEv9/o8PwDah7xH46/ukjCsI+labR6jxoX8YX9SRvUUm4FV9Vo2gkWi0IYM+k+VI6AyDFyhEzyJOIGHEY=
     on_failure: change
-

--- a/wrappers/java/src/main/java/org/ensembl/hive/RunWrapper.java
+++ b/wrappers/java/src/main/java/org/ensembl/hive/RunWrapper.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Constructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.misc.SharedSecrets;
+import jdk.internal.access.SharedSecrets;
 
 /**
  * Main class for running a hive worker in Java
@@ -79,10 +79,10 @@ public class RunWrapper {
 //		log.debug("Initializing runnable module " + clazz.getName() + " from " + args[1] + " and " + args[2]);
 
         FileDescriptor inputDescriptor = new FileDescriptor();
-        sun.misc.SharedSecrets.getJavaIOFileDescriptorAccess().set(inputDescriptor, Integer.parseInt(args[1]));
+        SharedSecrets.getJavaIOFileDescriptorAccess().set(inputDescriptor, Integer.parseInt(args[1]));
 
         FileDescriptor outputDescriptor = new FileDescriptor();
-        sun.misc.SharedSecrets.getJavaIOFileDescriptorAccess().set(outputDescriptor, Integer.parseInt(args[2]));
+        SharedSecrets.getJavaIOFileDescriptorAccess().set(outputDescriptor, Integer.parseInt(args[2]));
 
 		BaseRunnable runnable = (BaseRunnable) (ctor.newInstance());
         runnable.setFileDescriptors(inputDescriptor, outputDescriptor);

--- a/wrappers/java/wrapper
+++ b/wrappers/java/wrapper
@@ -42,7 +42,7 @@ elif [ "$action" == "compile" ]; then
 	fi
 	#echo "compiling:" mvn package
 	mvn package
-	exec java -cp target/eHive-*-jar-with-dependencies.jar org.ensembl.hive.CompileWrapper --add-exports java.base/jdk.internal.access=ALL-UNNAMED "$module"
+	exec java -cp target/eHive-*-jar-with-dependencies.jar --add-exports java.base/jdk.internal.access=ALL-UNNAMED org.ensembl.hive.CompileWrapper "$module"
 
 elif [ "$action" == "run" ]; then
 	if [[ -z "$module" || -z "$fd_in" || -z "$fd_out" || -z "$debug" ]]; then

--- a/wrappers/java/wrapper
+++ b/wrappers/java/wrapper
@@ -42,7 +42,7 @@ elif [ "$action" == "compile" ]; then
 	fi
 	#echo "compiling:" mvn package
 	mvn package
-	exec java -cp target/eHive-*-jar-with-dependencies.jar org.ensembl.hive.CompileWrapper "$module"
+	exec java -cp target/eHive-*-jar-with-dependencies.jar org.ensembl.hive.CompileWrapper --add-exports java.base/jdk.internal.access=ALL-UNNAMED "$module"
 
 elif [ "$action" == "run" ]; then
 	if [[ -z "$module" || -z "$fd_in" || -z "$fd_out" || -z "$debug" ]]; then
@@ -53,7 +53,7 @@ elif [ "$action" == "run" ]; then
 
 	#echo "Running in $PWD:" java -cp "lib/*" org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
 
-	exec java -cp target/eHive-*-jar-with-dependencies.jar org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
+	exec java -cp target/eHive-*-jar-with-dependencies.jar --add-exports java.base/jdk.internal.access=ALL-UNNAMED org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
 else
 	echo "Command-line error: No mode provided"
 	echo "$usage"


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

To avoid licence violation we must move to open jdk  in Java wrapper

## Description

move java wrapper to the latest JDK, in order to do it we need only change sun.misc.SharedSecrets lib import and RunWrapper.java call.

## Possible Drawbacks

Won't work on JDK 11 and 10 as they have SharedSecrets in jdk.internal, and JDK 12 - 13 has this in jdk.access 

## Testing

Needs changes in travis installation (install JDK-13) 

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_