### PR TITLE
wrappers/java/pom.xml: bump jackson-databind to 2.9.9

### DIFF
--- a/wrappers/java/pom.xml
+++ b/wrappers/java/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.1</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Use case

Version 2.6.1 of jackson-databind suffers from 5 high-severity and 1 moderate-severity security vulnerabilities. Use the first version known to fix all of these vulnerabilities.

Incidentally, all but one of these vulnerabilities date back to 2018 and earlier so one can't help but wonder why, seeing as this file was only introduced mid-May 2019, we used such an old and buggy version in the first place.

Come to think of it, why use fixed versions of Java dependencies rather than ranges?

## Description

Bump the version number of jackson-databind, one of the dependencies of the eHive Java wrapper, to 2.9.9 in order to address security vulnerabilities in 2.6.1.

## Possible Drawbacks

jackson-databind-2.9.9 may be incompatible with out code base. I haven't seen anything suggesting that it might in its release docs, that said I haven't tested it because of the size of Maven and co.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes (on Perl 5.26), no errors seen.