### PR TITLE
New script to peek at job parameters

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -19,9 +19,7 @@ package Bio::EnsEMBL::Hive::Scripts::PeekJob;
 
 use strict;
 use warnings;
-
 use Data::Dumper;
-$Data::Dumper::Sortkeys = 1;
 
 sub peek {
     my ($pipeline, $job_id) = @_;
@@ -32,10 +30,23 @@ sub peek {
     # fetch job and populate params
     my $job_adaptor = $hive_dba->get_AnalysisJobAdaptor;
     my $job = $job_adaptor->fetch_by_dbID( $job_id );
+    die "Cannot find job with id $job_id\n" unless $job;
     $job->load_parameters;
+    my $analysis_id = $job->analysis_id;
+    my $logic_name  = $job->analysis->logic_name;
 
-    my $unsub_params = $job->{'_unsubstituted_param_hash'};
-    return Data::Dumper->Dump( [ $unsub_params ], [ qw(*unsubstituted_param_hash) ] );
+    my $label = "[ Analysis $logic_name ($analysis_id) Job $job_id ]";
+    return _stringify_params($job->{'_unsubstituted_param_hash'}, $label);
+}
+
+sub _stringify_params {
+    my ($params, $label) = @_;
+    
+    local $Data::Dumper::Sortkeys = 1;
+    local $Data::Dumper::Deepcopy = 1;
+    local $Data::Dumper::Indent   = 1;
+    
+    return Data::Dumper->Dump( [ $params ], [ qq(*unsubstituted_param_hash $label) ] );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+$Data::Dumper::Sortkeys = 1;
 
 sub peek {
     my ($pipeline, $job_id) = @_;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -1,22 +1,19 @@
-=head1 LICENSE
+#!/usr/bin/env perl
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2018] EMBL-European Bioinformatics Institute
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-=cut
-
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 package Bio::EnsEMBL::Hive::Scripts::PeekJob;
 
@@ -39,13 +36,6 @@ sub peek {
 
     my $unsub_params = $job->{'_unsubstituted_param_hash'};
     print Data::Dumper->Dump( [ $unsub_params ], [ qw(*unsubstituted_param_hash) ] );
-    
-    # my @ordered_params = sort { lc($a) cmp lc($b) } keys %$unsub_params;
-    # print "{\n";
-    # foreach my $param ( @ordered_params ) {
-    #     print "\t'$param' => '" . $unsub_params->{$param} . "',\n";
-    # }
-    # print "}\n";
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -1,0 +1,50 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+package Bio::EnsEMBL::Hive::Scripts::PeekJob;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+sub peek {
+    my ($pipeline, $job_id) = @_;
+
+    my $hive_dba = $pipeline->hive_dba;
+    die "Hive's DBAdaptor is not a defined Bio::EnsEMBL::Hive::DBSQL::DBAdaptor\n" unless $hive_dba and $hive_dba->isa('Bio::EnsEMBL::Hive::DBSQL::DBAdaptor');
+
+    # fetch job and populate params
+    my $job_adaptor = $hive_dba->get_AnalysisJobAdaptor;
+    my $job = $job_adaptor->fetch_by_dbID( $job_id );
+    $job->load_parameters;
+
+    my $unsub_params = $job->{'_unsubstituted_param_hash'};
+    print Dumper $unsub_params;
+    
+    # my @ordered_params = sort { lc($a) cmp lc($b) } keys %$unsub_params;
+    # print "{\n";
+    # foreach my $param ( @ordered_params ) {
+    #     print "\t'$param' => '" . $unsub_params->{$param} . "',\n";
+    # }
+    # print "}\n";
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -35,7 +35,7 @@ sub peek {
     $job->load_parameters;
 
     my $unsub_params = $job->{'_unsubstituted_param_hash'};
-    print Data::Dumper->Dump( [ $unsub_params ], [ qw(*unsubstituted_param_hash) ] );
+    return Data::Dumper->Dump( [ $unsub_params ], [ qw(*unsubstituted_param_hash) ] );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/PeekJob.pm
@@ -37,7 +37,7 @@ sub peek {
     $job->load_parameters;
 
     my $unsub_params = $job->{'_unsubstituted_param_hash'};
-    print Dumper $unsub_params;
+    print Data::Dumper->Dump( [ $unsub_params ], [ qw(*unsubstituted_param_hash) ] );
     
     # my @ordered_params = sort { lc($a) cmp lc($b) } keys %$unsub_params;
     # print "{\n";

--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -46,7 +46,7 @@ use Bio::EnsEMBL::Hive::Scripts::StandaloneJob;
 our @ISA         = qw(Exporter);
 our @EXPORT      = ();
 our %EXPORT_TAGS = ();
-our @EXPORT_OK   = qw( standaloneJob init_pipeline runWorker beekeeper generate_graph visualize_jobs db_cmd seed_pipeline tweak_pipeline get_test_urls get_test_url_or_die run_sql_on_db load_sql_in_db make_new_db_from_sqls make_hive_db safe_drop_database all_source_files);
+our @EXPORT_OK   = qw( standaloneJob init_pipeline runWorker beekeeper generate_graph visualize_jobs db_cmd seed_pipeline tweak_pipeline peekJob get_test_urls get_test_url_or_die run_sql_on_db load_sql_in_db make_new_db_from_sqls make_hive_db safe_drop_database all_source_files);
 
 our $VERSION = '0.00';
 
@@ -361,6 +361,24 @@ sub generate_graph {
 
 sub visualize_jobs {
     return _test_ehive_script('visualize_jobs', @_);
+}
+
+=head2 peekJob
+
+  Arg[1]      : String $url. The location of the database
+  Arg[2]      : Arrayref $args. Extra arguments given to peekJob.pl
+  Arg[3]      : String $test_name (optional). The name of the test
+  Example     : peekJob($url, [-job_id => 1], 'Check params for job 1');
+  Description : Very generic function to run peekJob.pl on the given database with the given arguments
+  Returntype  : None
+  Exceptions  : TAP-style
+  Caller      : general
+  Status      : Stable
+
+=cut
+
+sub peekJob {
+    return _test_ehive_script('peekJob', @_);
 }
 
 

--- a/scripts/peekJob.pl
+++ b/scripts/peekJob.pl
@@ -1,20 +1,4 @@
 #!/usr/bin/env perl
-
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2019] EMBL-European Bioinformatics Institute
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 use strict;
 use warnings;
 
@@ -29,7 +13,6 @@ BEGIN {
 use Getopt::Long qw(:config no_auto_abbrev);
 use Pod::Usage;
 
-use Bio::EnsEMBL::Hive::Version qw(report_versions);
 use Bio::EnsEMBL::Hive::HivePipeline;
 use Bio::EnsEMBL::Hive::Scripts::PeekJob;
 use Bio::EnsEMBL::Hive::Utils::URL;
@@ -40,10 +23,7 @@ main();
 
 
 sub main {
-    my ($url, $reg_conf, $reg_type, $reg_alias, $nosqlvc, $job_id); 
-    my ($help, $report_versions);
-
-    $|=1;   # make STDOUT unbuffered (STDERR is unbuffered anyway)
+    my ($url, $reg_conf, $reg_type, $reg_alias, $nosqlvc, $job_id, $help); 
 
     GetOptions(
 
@@ -59,7 +39,6 @@ sub main {
 
     # Other commands
                'h|help'                     => \$help,
-               'v|version|versions'         => \$report_versions,
     ) or die "Error in command line arguments\n";
 
     if (@ARGV) {
@@ -68,11 +47,6 @@ sub main {
 
     if ($help || !$job_id) {
         pod2usage({-exitvalue => 0, -verbose => 2});
-    }
-
-    if($report_versions) {
-        report_versions();
-        exit(0);
     }
 
     my $pipeline;
@@ -115,7 +89,7 @@ peekJob.pl is an eHive component script that allows us to peek into the paramete
 =head1 USAGE EXAMPLES
 
         # Check the params for job 123456
-    runWorker.pl -url mysql://username:secret@hostname:port/ehive_dbname -job_id 12345
+    peekJob.pl -url mysql://username:secret@hostname:port/ehive_dbname -job_id 12345
 
 =head1 OPTIONS
 
@@ -151,7 +125,9 @@ URL defining where database is located
 
 =item --job_id <id>
 
-run a specific Job defined by its database id
+which Job (as defined by its database id) to peek at
+
+=back
 
 =head2 Other options:
 
@@ -161,16 +137,12 @@ run a specific Job defined by its database id
 
 print this help
 
-=item --versions
-
-report both eHive code version and eHive database schema version
-
 =back
 
 =head1 LICENSE
 
     Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-    Copyright [2016-2018] EMBL-European Bioinformatics Institute
+    Copyright [2016-2019] EMBL-European Bioinformatics Institute
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/scripts/peekJob.pl
+++ b/scripts/peekJob.pl
@@ -1,5 +1,20 @@
 #!/usr/bin/env perl
 
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 use strict;
 use warnings;
 
@@ -171,4 +186,3 @@ report both eHive code version and eHive database schema version
 Please subscribe to the eHive mailing list:  http://listserver.ebi.ac.uk/mailman/listinfo/ehive-users  to discuss eHive-related questions or to be notified of our updates
 
 =cut
-

--- a/scripts/peekJob.pl
+++ b/scripts/peekJob.pl
@@ -96,7 +96,7 @@ sub main {
         die "ERROR : no database connection, the pipeline could not be accessed\n\n";
     }
 
-    Bio::EnsEMBL::Hive::Scripts::PeekJob::peek($pipeline, $job_id);
+    print Bio::EnsEMBL::Hive::Scripts::PeekJob::peek($pipeline, $job_id);
 }
 
 

--- a/scripts/peekJob.pl
+++ b/scripts/peekJob.pl
@@ -1,0 +1,174 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+    # Finding out own path in order to reference own components (including own modules):
+use Cwd            ();
+use File::Basename ();
+BEGIN {
+    $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) );
+    unshift @INC, $ENV{'EHIVE_ROOT_DIR'}.'/modules';
+}
+
+use Getopt::Long qw(:config no_auto_abbrev);
+use Pod::Usage;
+
+use Bio::EnsEMBL::Hive::Version qw(report_versions);
+use Bio::EnsEMBL::Hive::HivePipeline;
+use Bio::EnsEMBL::Hive::Scripts::PeekJob;
+use Bio::EnsEMBL::Hive::Utils::URL;
+
+Bio::EnsEMBL::Hive::Utils::URL::hide_url_password();
+
+main();
+
+
+sub main {
+    my ($url, $reg_conf, $reg_type, $reg_alias, $nosqlvc, $job_id); 
+    my ($help, $report_versions);
+
+    $|=1;   # make STDOUT unbuffered (STDERR is unbuffered anyway)
+
+    GetOptions(
+
+    # Connection parameters:
+               'url=s'                        => \$url,
+               'reg_conf|regfile|reg_file=s'  => \$reg_conf,
+               'reg_type=s'                   => \$reg_type,
+               'reg_alias|regname|reg_name=s' => \$reg_alias,
+               'nosqlvc'                      => \$nosqlvc,       # using "nosqlvc" instead of "sqlvc!" for consistency with scripts where it is a propagated option
+
+    # Task specification parameters:
+               'job_id=i'                   => \$job_id,
+
+    # Other commands
+               'h|help'                     => \$help,
+               'v|version|versions'         => \$report_versions,
+    ) or die "Error in command line arguments\n";
+
+    if (@ARGV) {
+        die "ERROR: There are invalid arguments on the command-line: ". join(" ", @ARGV). "\n";
+    }
+
+    if ($help || !$job_id) {
+        pod2usage({-exitvalue => 0, -verbose => 2});
+    }
+
+    if($report_versions) {
+        report_versions();
+        exit(0);
+    }
+
+    my $pipeline;
+
+    if($url or $reg_alias) {
+
+        $pipeline = Bio::EnsEMBL::Hive::HivePipeline->new(
+            -url                            => $url,
+            -reg_conf                       => $reg_conf,
+            -reg_type                       => $reg_type,
+            -reg_alias                      => $reg_alias,
+            -no_sql_schema_version_check    => $nosqlvc,
+        );
+        # $pipeline->hive_dba()->dbc->requires_write_access();
+
+    } else {
+        die "\nERROR: Connection parameters (url or reg_conf+reg_alias) need to be specified\n";
+    }
+
+    unless($pipeline->hive_dba) {
+        die "ERROR : no database connection, the pipeline could not be accessed\n\n";
+    }
+
+    Bio::EnsEMBL::Hive::Scripts::PeekJob::peek($pipeline, $job_id);
+}
+
+
+__DATA__
+
+=pod
+
+=head1 NAME
+
+peekJob.pl [options]
+
+=head1 DESCRIPTION
+
+peekJob.pl is an eHive component script that allows us to peek into the parameters of a given job.
+
+=head1 USAGE EXAMPLES
+
+        # Check the params for job 123456
+    runWorker.pl -url mysql://username:secret@hostname:port/ehive_dbname -job_id 12345
+
+=head1 OPTIONS
+
+=head2 Connection parameters:
+
+=over
+
+=item --reg_conf <path>
+
+path to a Registry configuration file
+
+=item --reg_alias <string>
+
+species/alias name for the eHive DBAdaptor
+
+=item --reg_type <string>
+
+type of the registry entry ("hive", "core", "compara", etc - defaults to "hive")
+
+=item --url <url string>
+
+URL defining where database is located
+
+=item --nosqlvc
+
+"No SQL Version Check" - set if you want to force working with a database created by a potentially schema-incompatible API
+
+=back
+
+=head2 Task specification parameters:
+
+=over
+
+=item --job_id <id>
+
+run a specific Job defined by its database id
+
+=head2 Other options:
+
+=over
+
+=item --help
+
+print this help
+
+=item --versions
+
+report both eHive code version and eHive database schema version
+
+=back
+
+=head1 LICENSE
+
+    Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+    Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+=head1 CONTACT
+
+Please subscribe to the eHive mailing list:  http://listserver.ebi.ac.uk/mailman/listinfo/ehive-users  to discuss eHive-related questions or to be notified of our updates
+
+=cut
+

--- a/t/03.scripts/peekJob_output.t
+++ b/t/03.scripts/peekJob_output.t
@@ -20,12 +20,9 @@ use strict;
 use warnings;
 
 use Test::More;
-use Data::Dumper;
-use Test::JSON;
-use JSON qw(decode_json);
 
 use Capture::Tiny ':all';
-use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline runWorker beekeeper get_test_url_or_die run_sql_on_db peekJob);
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline get_test_url_or_die peekJob);
 
 
 # eHive needs this to initialize the pipeline (and run db_cmd.pl)
@@ -43,7 +40,7 @@ my $stdout = capture_stdout {
     peekJob($pipeline_url, ["-job_id" => 1]);
 };
 $stdout =~ s/\s+//g;
-my $exp_stdout = "%unsubstituted_param_hash=('column_names'=>['value'],'inputlist'=>'#expr([0..#job_count#-1])expr#','job_count'=>10);";
+my $exp_stdout = "%unsubstituted_param_hash[Analysisgenerate_jobs(1)Job1]=('column_names'=>['value'],'inputlist'=>'#expr([0..#job_count#-1])expr#','job_count'=>10);";
 is( $stdout, $exp_stdout, 'Correct params reported' );
 
 done_testing();

--- a/t/03.scripts/peekJob_output.t
+++ b/t/03.scripts/peekJob_output.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Test::More;
+use Data::Dumper;
+use Test::JSON;
+use JSON qw(decode_json);
+
+use Capture::Tiny ':all';
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline runWorker beekeeper get_test_url_or_die run_sql_on_db peekJob);
+
+
+# eHive needs this to initialize the pipeline (and run db_cmd.pl)
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+my $pipeline_url = get_test_url_or_die();
+
+# Starting a first set of checks with a "GCPct" pipeline
+
+init_pipeline('Bio::EnsEMBL::Hive::Examples::FailureTest::PipeConfig::FailureTest_conf', $pipeline_url);
+
+my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+
+my $stdout = capture_stdout {
+    peekJob($pipeline_url, ["-job_id" => 1]);
+};
+$stdout =~ s/\s+//g;
+my $exp_stdout = "%unsubstituted_param_hash=('column_names'=>['value'],'inputlist'=>'#expr([0..#job_count#-1])expr#','job_count'=>10);";
+is( $stdout, $exp_stdout, 'Correct params reported' );
+
+done_testing();


### PR DESCRIPTION
peekJob.pl allows us to check which params a given job has access to

## Use case

Sometimes, we need to see which parameters a job has access to during development or testing. This is currently only possible by running runWorker.pl in debug mode and killing the job before it performs any other tasks.

## Description

Utilising the method that runWorker.pl itself uses to fetch params, this script has been implemented following the general structure of the e-hive codebase (with a module for the main functionality and a script to pass the parameters)

## Possible Drawbacks

This script does not reveal any information about the source of the parameters, only their presence

## Testing

Added new unit test to check the output of the script
