### PR TITLE
JDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_install:
     - tar xvzf openjdk-12.0.1_linux-x64_bin.tar.gz
     - export JAVA_HOME=$PWD/jdk-12.0.1
     - export PATH=$JAVA_HOME/bin:$PATH
-    - export JAVA_JRE=$JAVA_HOME
     - cd $EHIVE_HOME
     - ls $JAVA_HOME
     - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
   apt:
     packages:
     - python3
-    #- oracle-java8-installer      # Installed by default on Trusty
     - maven
     - graphviz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ before_install:
     - ln -s /usr/share/perl5/PgCommon.pm deps/
     - export EHIVE_HOME=$PWD
     - cd ../
-    - wget https://download.java.net/java/early_access/jdk13/21/GPL/openjdk-13-ea+21_linux-x64_bin.tar.gz
-    - tar xvzf openjdk-13-ea+21_linux-x64_bin.tar.gz
-    - export JAVA_HOME=$PWD/jdk-13
+    - wget https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz
+    - tar xvzf openjdk-12.0.1_linux-x64_bin.tar.gz
+    - export JAVA_HOME=$PWD/jdk-12.0.1
     - export PATH=$JAVA_HOME/bin:$PATH
     - export JAVA_JRE=$JAVA_HOME
     - cd $EHIVE_HOME

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@
 
 FROM ubuntu:16.04
 
-# Install git and java (taken from https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile)
+# Install git and java
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
     && apt-get install -y git software-properties-common openjdk-8-jdk ant \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,19 @@
 
 FROM ubuntu:16.04
 
-# Install git and java
+# Install some basic utilities
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
-    && apt-get install -y git software-properties-common openjdk-8-jdk ant \
+    && apt-get install -y git maven curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Intall java
+RUN mkdir -p /opt \
+    && curl -SL https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz \
+    | tar -xzC /opt
+ENV JAVA_HOME=/opt/jdk-12.0.1
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Clone the repo
 RUN mkdir /repo && git clone -b version/2.5 https://github.com/Ensembl/ensembl-hive.git /repo/ensembl-hive

--- a/docker/setup_cpan.Ubuntu-16.04.sh
+++ b/docker/setup_cpan.Ubuntu-16.04.sh
@@ -31,6 +31,6 @@ do
 	[ -f "$arg/cpanfile" ] && cpanm --installdeps --with-recommends "$arg"
 done
 # Cleanup the cache and remove the build dependencies to reduce the disk footprint
-rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/* /root/.cpanm
 apt-get purge -y --auto-remove $buildDeps
 

--- a/docs/quickstart/install.rst
+++ b/docs/quickstart/install.rst
@@ -101,6 +101,20 @@ If installation of either DBD::mysql or DBD::Pg fails, check that the
 corresponding database system (MySQL or PostgreSQL) was installed
 correctly.
 
+Guest languages
+---------------
+
+If you wish to use runnable modules written in Python or Java, then an appropriate
+version of Python or Java will need to be installed on your system:
+
+-  *Python:*
+
+   Python 3 is required. It is known to work with Python 3.5.1 or later, earlier
+   Python versions may work but have not been tested.
+
+-  *Java:*
+
+   Requires OpenJDK version 12 or later, along with Apache Maven.
 
 Configuration
 -------------


### PR DESCRIPTION
## Use case

The 2.5 Docker image cannot run the Java wrapper since it doesn't have maven/openjdk installed.

## Description

Various commits, related to the Docker image and the JDK version:
- use OpenJDK 12 as it is the only released version that has the necessary dependencies (on both Travis and Docker)
- minor cleanup of the Docker image

By the way, if you have written any update to the doc / install guide for OpenJDK, can you add it to this branch ? If not, I will add something now

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

Not needed

_Have you run the entire test suite and no regression was detected?_

Yes. OK