### PR TITLE
[codecov] Only report a failure when the coverage decreases by more than 1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,9 +4,13 @@ codecov:
     after_n_builds: 1
 
 coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
   notify:
     slack:
       default:
         url: secret:LW+i/4NzE9beqqJetobJEJP8GowY1eHWyaiIJM7BB5ZMET5oak4rsGK9zznYFaLQ0jncm46ES7b+aDshLPEMyYp+fvtM/QL0C1+n+nP1tQhzt+kQeFdj5eZA2VBm5qYQq7FuaS1p7PpWEY1EeuQkFWNWQMKNDkeO/ZSrqaiWRUQ=
-        threshold: 0
+        threshold: 1%
 


### PR DESCRIPTION

## Use case

I've always found it very annoying that codecov complains about meaningless decreases of the coverage, like `80.88% (-0.04%) compared to e2e90e5 `. Coveralls has been configured to not report small differences but I couldn't find how to configure this in codecov ... until today :)

## Description

Do not complain about small decreases of the coverage

## Possible Drawbacks

Does anyone need such precision and fine-grain decision in the codecov report ?

## Testing

_Have you added/modified unit tests to test the changes?_

N/A, but I have checked that the yaml file is valid with
```
curl --data-binary @.codecov.yml https://codecov.io/validate
```

_Have you run the entire test suite and no regression was detected?_

N/A