### PR TITLE
Explicitly enable database services for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ env:
 
 sudo: false
 
-before_install:
-    - echo -e '#!/bin/bash\n\nperl '`which psql`' "$@"' > psql
-    - chmod +x psql
-    - export PATH=$PWD:$PATH
-    - ln -s /usr/share/perl5/PgCommon.pm modules/
-
-
 install:
     - cpanm -v --installdeps --notest .
     - cpanm -n Devel::Cover::Report::Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ perl:
   - "5.14"
   - "5.26"
 
+services:
+  - mysql
+  - postgresql
+
 env:
   - COVERALLS=true
   - COVERALLS=false


### PR DESCRIPTION
## Use case

From Xenial onwards services such as MySQL or PostgreSQL have to be explicitly enabled in .travis.yml. Due to issues with the availability of Perl versions we need we will stick with Trusty for the time being in spite of it being deprecated (see #112), then again it doesn't hurt to get this taken care of already.

## Description

Explicitly enable the services: mysql and postgresql in Travis builds.

## Possible Drawbacks

None I can think of, enabling these services for Trusty is harmless.

## Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

The change pertains specifically to Travis so running the test suite by hand doesn't help, have to wait for Travis builds on the head branch to finish.