### PR TITLE
update rtd_upgrade.sh and xhive in response to readthedocs stable bui…

### DIFF
--- a/docs/rtd_upgrade.sh
+++ b/docs/rtd_upgrade.sh
@@ -23,14 +23,18 @@ rm -rf "$1"
 mkdir -p "$1"
 cd "$1"
 
+echo ISSUE
+cat /etc/issue
+echo PERLVERSION
+perl --version
 mkdir packages
 cd packages
 # List of extra packages we need
-echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.634-1build1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.50-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libj/libjson-xs-perl/libjson-xs-perl_3.010-2build1_amd64.deb \
+echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.640-1_amd64.deb \
+     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.58-1_amd64.deb \
+     http://archive.ubuntu.com/ubuntu/pool/universe/libj/libjson-xs-perl/libjson-xs-perl_3.040-1_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/main/libj/libjson-perl/libjson-perl_2.90-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libc/libcommon-sense-perl/libcommon-sense-perl_3.74-1build1_amd64.deb \
+     http://archive.ubuntu.com/ubuntu/pool/universe/libc/libcommon-sense-perl/libcommon-sense-perl_3.74-2build2_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/main/libt/libtypes-serialiser-perl/libtypes-serialiser-perl_1.0-1_all.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libx/libxml-xpath-perl/libxml-xpath-perl_1.30-1_all.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libp/libparse-recdescent-perl/libparse-recdescent-perl_1.967013+dfsg-1_all.deb \

--- a/docs/xhive/__init__.py
+++ b/docs/xhive/__init__.py
@@ -42,7 +42,7 @@ def setup_if_needed(this_release, run_doxygen):
         if not is_same:
             subprocess.check_call(["./rtd_upgrade.sh", upgrade_path], stdout=sys.stdout, stderr=sys.stderr)
         deb_install_path = os.path.join(upgrade_path, "root")
-        os.environ["PERL5LIB"] = os.path.pathsep.join(os.path.join(deb_install_path, _) for _ in ["usr/share/perl5/", "usr/lib/x86_64-linux-gnu/perl5/5.22/", "usr/lib/x86_64-linux-gnu/perl5/5.22/auto/"])
+        os.environ["PERL5LIB"] = os.path.pathsep.join(os.path.join(deb_install_path, _) for _ in ["usr/share/perl5/", "usr/lib/x86_64-linux-gnu/perl5/5.26/", "usr/lib/x86_64-linux-gnu/perl5/5.26/auto/"])
         os.environ["PATH"] = os.path.join(deb_install_path, "usr/bin") + os.path.pathsep + os.environ["PATH"]
         os.environ["ENSEMBL_CVS_ROOT_DIR"] = upgrade_path
     else:

--- a/docs/xhive/analysis_diagram.py
+++ b/docs/xhive/analysis_diagram.py
@@ -133,6 +133,8 @@ def generate_dot_diagram(pipeconfig_content):
 
     # Run generate_graph and read the content of the dot file
     graph_path = os.path.join(os.environ["EHIVE_ROOT_DIR"], "scripts", "generate_graph.pl")
+    if os.environ["PERL5LIB"][-2:] != ":.":
+        os.environ["PERL5LIB"] = os.environ["PERL5LIB"] + ":."
     dotcontent = subprocess.check_output([graph_path, "-pipeconfig", pipeconfig_fh.name, "--format", "dot", "-config_file", default_config_file, "-config_file", json_filename], stderr=sys.stderr)
 
     return dotcontent.decode()


### PR DESCRIPTION
…ld image update

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

Readthedocs.io changed the configuration of their "stable" build image. We had to update the debs downloaded in rtd_upgrade.sh, as well as make some modifications in the xhive Python scripts to compensate

## Description

Download list updated in rtd_upgrade.sh, PERL5LIB manipulation updated in xhive Python scripts that spawn Perl processes. Also added some debugging output to rtd_upgrade.sh to help the next time this happens.

## Possible Drawbacks

These are very version-specific fixes that will need to be updated the next time there is a change in readthedocs.io's build image

## Testing

_Have you added/modified unit tests to test the changes?_

N/A
_If so, do the tests pass/fail?_

N/A
_Have you run the entire test suite and no regression was detected?_

Yes, building on readthedocs.io ehive-docbuild-test private build area
https://ehive-docbuild-test.readthedocs.io/en/version-2.5/