### PR TITLE
Report the command that is failing

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
@@ -396,7 +396,7 @@ sub run_pipeline_create_commands {
         (my $dummy,$cmd) = join_command_args($cmd);
         $self->print_debug( "$cmd\n" );
         if(my $retval = system($cmd)) {
-            die "Return value = $retval, possibly an error\n";
+            die "Return value = $retval, possibly an error running $cmd\n";
         }
     }
     $self->print_debug( "\n" );


### PR DESCRIPTION
## Use case

Since 2.5, the commands being run are by default hidden (they can be shown with the `-hive_debug_init 1` flag), so if something goes wrong, you can only see the error message, not the command that caused the error.

## Description

When the command fails, print it too, alongside the error message.

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
