### PR TITLE
Exclude "/" from pipeline names too as it causes problems in URLs

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
@@ -305,7 +305,7 @@ sub process_pipeline_name {
     my ($self, $ppn) = @_;
 
     $ppn=~s/([[:lower:]])([[:upper:]])/${1}_${2}/g;   # CamelCase into Camel_Case
-    $ppn=~s/\s/_/g;                                   # remove all spaces
+    $ppn=~s/[\s\/]/_/g;                               # remove all spaces and other annoying characters
     $ppn = lc($ppn);
 
     return $ppn;


### PR DESCRIPTION

## Use case

Jorge found this one by accident. He had put a `/` in the `pipeline_name` option and then generate_graph.pl failed with this error
```Error: <stdin>: syntax error in line 119 near '/'```

When doing my own tests, I realized that the URLs themselves would be confusing with a `/` in the database name, so better to remove them early on.

## Description

Just like whitespace, replace the `/` with an underscore

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

No, that function is not currently tested.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
