### PR TITLE
readability fixes

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Worker.pm
+++ b/modules/Bio/EnsEMBL/Hive/Worker.pm
@@ -255,7 +255,7 @@ sub current_role {
         }
         my $new_role = shift @_;
         if( my $to_analysis = $new_role && $new_role->analysis ) {
-            $self->worker_say( "specializing to ".$to_analysis->logic_name.'('.($to_analysis->dbID // 'unstored').')' );
+            $self->worker_say( "specializing to " . $to_analysis->logic_name . '('.($to_analysis->dbID // 'unstored') . ')' );
         }
         $self->{'_current_role'} = $new_role;
     }

--- a/t/05.runnabledb/java.t
+++ b/t/05.runnabledb/java.t
@@ -28,7 +28,7 @@ use Test::More;
 use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
 
 SKIP: {
-    skip "mvn not installed", 1 unless(`mvn -version 2>/dev/null`);
+    skip "mvn not installed", 1 unless (`mvn -version 2>/dev/null`);
 
 plan tests => 1;
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

@mkszuba noted that we have an opportunity to make some readability fixes with the changes brought in with #108. We should make these fixes in 2.5 as well, as long as we're making them - we get a slightly cleaner commit history this way, too.

## Description

Added whitespace where it will add clarity, in lines that were new or being changed anyway.

## Possible Drawbacks

Authorship of functional change is one commit off on a couple of lines

## Testing

_Have you added/modified unit tests to test the changes?_
 N/A
_If so, do the tests pass/fail?_
N/A
_Have you run the entire test suite and no regression was detected?_
Yes