### PR TITLE
pipeline_url quoting

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
@@ -606,7 +606,7 @@ sub useful_commands_legend {
 
     my $pipeline_url = $self->pipeline_url();
     unless ($pipeline_url =~ /^[\'\"]/) {
-        my $pipeline_url    = '"' . $pipeline_url . '"';
+        $pipeline_url   = '"' . $pipeline_url . '"';
     }
     my $pipeline_name   = $self->o('pipeline_name');
     my $extra_cmdline   = $self->beekeeper_extra_cmdline_options();

--- a/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm
@@ -44,6 +44,7 @@ sub init_pipeline {
     if ($pipeconfig_object->pipeline_url =~ /\$\{_EHIVE_HIDDEN_PASS\}/) {
         my $real_password = $ENV{_EHIVE_HIDDEN_PASS};
         $pipeconfig_object->root()->{'pipeline_url'} =~ s/\$\{_EHIVE_HIDDEN_PASS\}/$real_password/;
+        $pipeconfig_object->root()->{'pipeline_url'} =~ s/'//g;
     }
 
     print "> Running the creation commands.\n\n";

--- a/modules/Bio/EnsEMBL/Hive/Utils/URL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/URL.pm
@@ -304,7 +304,7 @@ sub hide_url_password {
                 # Perform the substitution
                 my $pass_variable = '_EHIVE_HIDDEN_PASS';
                 $ENV{$pass_variable} = $possible_password;
-                # Double quotes are needed so that LSF doesn't expand the variable
+                # Single quotes are needed so that LSF doesn't expand the variable
                 $url = q{'} . $driver_and_user .'${'.$pass_variable . '}' . $url_remainder . q{'};
             }
             # Found the URL, let's push the remaining arguments and exec

--- a/t/10.pipeconfig/TestPipeConfig/PipelineURL_conf.pm
+++ b/t/10.pipeconfig/TestPipeConfig/PipelineURL_conf.pm
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an intentionally broken PipeConfig for testing purposes.
+# It has a flow_into that goes to an analysis that is not defined
+# in the pipeline.
+
+package TestPipeConfig::PipelineURL_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
+
+sub pipeline_analyses {
+    my ($self) = @_;
+    return [
+        { -logic_name  => 'first',
+          -module      => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+          -parameters  => {
+              'url' => $self->pipeline_url(),
+          },
+        },
+    ];
+}
+1;

--- a/t/10.pipeconfig/pipeline_url.t
+++ b/t/10.pipeconfig/pipeline_url.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2019] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline beekeeper get_test_url_or_die safe_drop_database);
+use Bio::EnsEMBL::Hive::Utils qw(destringify);
+
+# eHive needs this to initialize the pipeline (and run db_cmd.pl)
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+my $pipeline_url  = get_test_url_or_die();
+
+# Utils::Test::init_pipeline runs things internally instead of invoking init_pipeline.pl
+# Here we need to run the script to trigger the password sanitization
+my @cmd = ('env', 'PERL5LIB='.$ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/::'.$ENV{PERL5LIB}, $ENV{'EHIVE_ROOT_DIR'}.'/scripts/init_pipeline.pl', 'TestPipeConfig::PipelineURL_conf', -pipeline_url => $pipeline_url);
+my $rc = system(@cmd);
+is($rc, 0, 'init_pipeline.pl successfully ran');
+
+my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+
+my $analysis = $hive_dba->get_AnalysisAdaptor->fetch_by_logic_name('first');
+my $params = destringify($analysis->parameters);
+ok(exists $params->{'url'}, '"url" parameter is there');
+is($params->{'url'}, $pipeline_url, "URL is correct");
+
+safe_drop_database( $hive_dba );
+
+done_testing();
+


### PR DESCRIPTION
## Use case

@JAlvarezJarreta and @carlacummins  found an issue in one of the Compara pipelines this morning.
The pipeline defines a SystemCmd with the pipeline's URL, calling `$self->pipeline_url()` (see https://github.com/Ensembl/ensembl-compara/blob/release/97/modules/Bio/EnsEMBL/Compara/PipeConfig/Synteny_conf.pm#L139). When the pipeline is initialized by explictly giving `-pipeline_url`, the URL ends up being wrapped in quotes. It is thus not a valid URL any more.

```
$ init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::EBI::Plants::Synteny_conf -pipeline_url 'mysql://ensadmin:xxxxx@mysql-ens-compara-prod-1.ebi.ac.uk:4485/muffato_plants_synteny_98'
$ tweak_pipeline.pl -url mysql://ensro@mysql-ens-compara-prod-1.ebi.ac.uk:4485/muffato_plants_synteny_98 -tweak 'analysis[1].param[cmd]?'
 
Tweak.Request   analysis[1].param[cmd]?
Tweak.Found     1 analyses matching the pattern '1'
Tweak.Show      analysis[populate_new_database].param[cmd] ::   ["#program#","--master","compara_master","--new","'mysql://ensadmin:xxxxx\@mysql-ens-compara-prod-1.ebi.ac.uk:4485/muffato_plants_synteny_98'","--reg-conf","#registry#"]
```

## Description

The quotes are introduced by the `hide_url_password` function, see https://github.com/Ensembl/ensembl-hive/blob/version/2.5/modules/Bio/EnsEMBL/Hive/Utils/URL.pm#L308 and are removed by `parse` https://github.com/Ensembl/ensembl-hive/blob/version/2.5/modules/Bio/EnsEMBL/Hive/Utils/URL.pm#L45-L48 but the latter isn't called in all cases. In particular, `$self->pipeline_url()` in PipeConfigs returns the URL as given on the command-line, without parsing it (but after restoring the password https://github.com/Ensembl/ensembl-hive/blob/version/2.5/modules/Bio/EnsEMBL/Hive/Scripts/InitPipeline.pm#L42-L47). My change is to make the init_pipeline removes the quotes too.

Related to that, I've fixed a comment and the quoting of the URL when it is display in the "useful commands"

## Possible Drawbacks

Maybe others didn't see this as a bug and are now expecting the URL to be wrapped in single-quotes ?

## Testing

_Have you added/modified unit tests to test the changes?_

Yep

_If so, do the tests pass/fail?_

Yep

_Have you run the entire test suite and no regression was detected?_

Yes: ok.