### PR TITLE
com.fasterxml.jackson.core 2.9.9 has a vulnerability

### DIFF
--- a/wrappers/java/pom.xml
+++ b/wrappers/java/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Use case

See https://github.com/Ensembl/ensembl-hive/network/alert/wrappers/java/pom.xml/com.fasterxml.jackson.core:jackson-databind/open and https://nvd.nist.gov/vuln/detail/CVE-2019-12814 for a description of the vulnerability.
I'm not aware of anyone using Java and eHive (I'm only aware of plans to do so) but I thought. Let's patch this and make GitHub happy.

## Description

Just bumped to 2.9.9.1. I don't want to define to an open interval as this is version/2.5, which shouldn't get any significant changes, and upstream may break the interface in a 3.* version.

## Possible Drawbacks

2.9.9.1 seems compatible, so I can't see any drawbacks

## Testing

_Have you added/modified unit tests to test the changes?_

Nothing to change.

_Have you run the entire test suite and no regression was detected?_

Yes. OK