### PR TITLE
bugfix: this needs to match the source code

### DIFF
--- a/wrappers/java/pom.xml
+++ b/wrappers/java/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.ensembl.hive</groupId>
   <artifactId>eHive</artifactId>
-  <version>3.1</version>
+  <version>4.0</version>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
## Use case

At the moment beekeeper will report that the Java wrapper has an incompatible version.

## Description

The implementation is already compatible with the 4.* interface, but I forgot to change the version number in pom.xml in #110 / #111 

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_Have you run the entire test suite and no regression was detected?_

Yes