### PR TITLE
This should have stayed commented out

### DIFF
--- a/scripts/dev/simple_init.py
+++ b/scripts/dev/simple_init.py
@@ -42,7 +42,7 @@ def wait_for_all_processes(ref_pid):
         try:
             # Wait for any child
             child_pid, child_status = os.waitpid(-1, 0)
-            print("ripped a child", child_pid, child_status)
+            #print("ripped a child", child_pid, child_status)
             # Get the exit status (the reference process has the priority)
             if child_pid == ref_pid:
                 ref_status = child_status


### PR DESCRIPTION
## Use case

When running an eHive docker container it will print "ripped a child" when exiting. This was meant to be a debug statement, mistakenly uncommented during #130 

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes