### PR TITLE
com.fasterxml.jackson.core 2.9.9.1 has a vulnerability

### DIFF
--- a/wrappers/java/pom.xml
+++ b/wrappers/java/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.1</version>
+      <version>[2.9,2.10)</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/wrappers/java/pom.xml
+++ b/wrappers/java/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>[2.9,2.10)</version>
+      <version>[2.9.9.2,2.10)</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Use case

See:
- https://github.com/Ensembl/ensembl-hive/network/alert/wrappers/java/pom.xml/com.fasterxml.jackson.core:jackson-databind/open
- https://nvd.nist.gov/vuln/detail/CVE-2019-14379
- https://nvd.nist.gov/vuln/detail/CVE-2019-14439

## Description

Follow-up of #131. There could be more vulnerabilities, so I'm switching to an open interval to pick up the latest 2.9.9.* version

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_

Nothing to change.

_Have you run the entire test suite and no regression was detected?_

Yes