### PR TITLE
Test using the latest Perl on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: "perl"
 
 perl:
   - "5.14"
-  - "5.26"
+  - "5.30"
 
 services:
   - mysql
@@ -39,5 +39,5 @@ matrix:
   exclude:
     - perl: "5.14"
       env: COVERALLS=true
-    - perl: "5.26"
+    - perl: "5.30"
       env: COVERALLS=false


### PR DESCRIPTION
## Use case

Perl 5.14 not being available on Travis @ xenial, Ensembl as a whole is considering a bump of the minimal version (@s-mm brought this up to the ops meeting). All the teams have to start testing on the latest Perl, which is 5.30

## Description

Just bumped the version in .travis.yml

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes