### PR TITLE
[GuestLanguage/java] Don't run the tests in the before_install section as they are run by scripts/dev/travis_run_tests.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
     - env
     - cd wrappers/java
     - mvn -Dmaven.repo.local=$HOME/deps/maven clean
-    - mvn -Dmaven.repo.local=$HOME/deps/maven package
+    - mvn -Dmaven.repo.local=$HOME/deps/maven -Dmaven.test.skip=true package
     - cd ../..
 
 install:


### PR DESCRIPTION
## Use case

The Java tests are currently run twice: in `before_install` and in `scripts/dev/travis_run_tests.sh`. This causes two issues:
 - extra Travis time, which is really precious and should not be wasted
 - The test build will immediately fail and only report the Java error. There could be other errors worth being reported part of the build

## Description

Only run the tests in `scripts/dev/travis_run_tests.sh` (like all the other tests).

## Possible Drawbacks

Extra Travis time when the only issue is that the Java wrapper doesn't pass its own tests. But the same could be said of any components. It would make sense to test (and fail early) the critical components, but I don't think the Java wrapper is currently critical.

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_Have you run the entire test suite and no regression was detected?_

N/A