### PR TITLE
Throw if the requested registry file doesn't exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ before_install:
     - eval "$(perl -Mlocal::lib=${HOME}/deps)"
     - mkdir deps
     - cd deps
+    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl
+    - export PERL5LIB=$PWD/ensembl/modules:$PERL5LIB
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
     - export PERL5LIB=$PWD/bioperl-live:$PERL5LIB
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
@@ -63,6 +65,7 @@ before_install:
 
 install:
     - cpanm -v --installdeps --with-recommends --notest .
+    - cpanm -v --installdeps --notest --cpanfile deps/ensembl/cpanfile .
     - cpanm -n Devel::Cover::Report::Coveralls
     - cpanm -n Devel::Cover::Report::Codecov
     - ls $HOME/deps

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
@@ -56,6 +56,7 @@ use Bio::EnsEMBL::Hive::AnalysisCtrlRule;
 use Bio::EnsEMBL::Hive::DataflowRule;
 use Bio::EnsEMBL::Hive::DataflowTarget;
 
+my $default_reg_type = 'hive';
 
 sub new {
     my $class = shift @_;
@@ -99,7 +100,7 @@ sub new {
         }
 
         unless($self) {         # otherwise (or if not found) try a specific $reg_type
-            $reg_type ||= 'hive';
+            $reg_type ||= $default_reg_type;
             $self = Bio::EnsEMBL::Registry->get_DBAdaptor($reg_alias, $reg_type)
                 or die "Unable to connect to DBA using reg_conf='$reg_conf', reg_type='$reg_type', reg_alias='$reg_alias'\n";
         }
@@ -164,7 +165,7 @@ sub new {
 
     if($species) {      # [compatibility with core code] store the DBAdaptor in Registry:
         require Bio::EnsEMBL::Registry;
-        Bio::EnsEMBL::Registry->add_DBAdaptor( $species, 'hive', $self );
+        Bio::EnsEMBL::Registry->add_DBAdaptor( $species, $default_reg_type, $self );
     }
 
     return $self;
@@ -176,7 +177,7 @@ sub species {   # a stub to please Registry code
 }
 
 sub group {     # a stub to please Registry code
-    return 'hive';
+    return $default_reg_type;
 }
 
 

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
@@ -165,6 +165,7 @@ sub new {
 
     if($species) {      # [compatibility with core code] store the DBAdaptor in Registry:
         require Bio::EnsEMBL::Registry;
+        $self->{'_species'} = $species;
         Bio::EnsEMBL::Registry->add_DBAdaptor( $species, $default_reg_type, $self );
     }
 
@@ -173,7 +174,8 @@ sub new {
 
 
 sub species {   # a stub to please Registry code
-    return @_;
+    my $self = shift;
+    return $self->{'_species'} // "$self";
 }
 
 sub group {     # a stub to please Registry code

--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
@@ -72,7 +72,8 @@ sub new {
 
     if($reg_conf or $reg_alias) {   # need to initialize Registry even if $reg_conf is not really given
         require Bio::EnsEMBL::Registry;
-        Bio::EnsEMBL::Registry->load_all($reg_conf);    # if undefined, default reg_conf will be used
+        # if undefined, default reg_conf will be used. If missing, will throw
+        Bio::EnsEMBL::Registry->load_all($reg_conf, undef, undef, undef, 'throw_if_missing');
     }
 
     my $self;

--- a/t/01.utils/dba_dbc.t
+++ b/t/01.utils/dba_dbc.t
@@ -52,19 +52,24 @@ my $dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new(-url => $pipeline_url,
 						   -no_sql_schema_version_check => 1);
 my $dba2dbc = go_figure_dbc($dba);
 isa_ok($dba2dbc, 'Bio::EnsEMBL::Hive::DBSQL::DBConnection');
+like($dba->species, qr/^Bio::EnsEMBL::Hive::DBSQL::DBAdaptor=HASH\(0x[[:xdigit:]]+\)$/, 'The DBAdaptor has a unique "species" name');
 
 SKIP: {
     eval { require Bio::EnsEMBL::Registry; };
 
     skip "The Ensembl Core API is not installed" if $@;
 
+    my $registry_species_name = 'dummy_species';
+
     my $dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new(
         -url => $pipeline_url,
-        -species => 'dummy_species',
+        -species => $registry_species_name,
         -no_sql_schema_version_check => 1,
     );
 
-    my $dba_from_registry = Bio::EnsEMBL::Registry->get_DBAdaptor('dummy_species', 'hive');
+    is($dba->species, $registry_species_name, 'The DBAdaptor has the correct "species" name');
+
+    my $dba_from_registry = Bio::EnsEMBL::Registry->get_DBAdaptor($registry_species_name, 'hive');
     is($dba_from_registry, $dba, 'The DBAdaptor is registered in the Ensembl Registry');
 
     throws_ok {

--- a/t/01.utils/go_figure_dbc.t
+++ b/t/01.utils/go_figure_dbc.t
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 use Data::Dumper;
 
 use Bio::EnsEMBL::Hive::Utils qw(go_figure_dbc);
@@ -51,5 +52,9 @@ my $dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new(-url => $pipeline_url,
 						   -no_sql_schema_version_check => 1);
 my $dba2dbc = go_figure_dbc($dba);
 isa_ok($dba2dbc, 'Bio::EnsEMBL::Hive::DBSQL::DBConnection');
+
+throws_ok {
+    Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new(-reg_conf => '/non_existent_file');
+} qr/Configuration file .* does not exist. Registry configuration not loaded/, 'Throws a relevant message if the path doesn\'t exist';
 
 done_testing();


### PR DESCRIPTION
## Use case

When a worker or beekeeper is invoked with a wrong reg_conf argument, there is no explicit warning / error message, only potentially an error about the reg_alias not being found in the Registry.

## Description

`Registry::load_all` already has a flag to require the file to exist. I merely enable it and we now get a much clearer error message.

## Possible Drawbacks

This is a breaking change for people who use a url _and_ an invalid reg_conf at the same time. Previously, there would have been no warnings about the invalid reg_conf, and the database would have been connected to via its URL. Now eHive is going to complain about the reg_conf,

## Testing

_Have you added/modified unit tests to test the changes?_

Yes, but requires Ensembl/ensembl#408

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes