### PR TITLE
bugfix: allow generating graphs of pipelines with a dot in their name

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils/Graph.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Graph.pm
@@ -329,6 +329,7 @@ sub _add_pipeline_label {
     my $node_fontname       = $self->config_get('Node', 'Details', 'Font');
     my $pipeline_label      = $pipeline->display_name;
     my $pipelabel_node_name = 'pipelabel_'.$pipeline->hive_pipeline_name;
+       $pipelabel_node_name =~ s/\./_/g;
 
     $self->graph()->add_node( $pipelabel_node_name,
         shape     => 'plaintext',

--- a/modules/Bio/EnsEMBL/Hive/Utils/GraphViz.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/GraphViz.pm
@@ -123,7 +123,7 @@ sub display_subgraph {
 
     my $prefix = "\t" x $depth;
     my  $text = '';
-        $text .= $prefix . "subgraph cluster_${cluster_name} {\n";
+        $text .= $prefix . "subgraph \"cluster_${cluster_name}\" {\n";
 
         # uncomment the following line to see the cluster names:
 #     $text .= $prefix . "\tlabel=\"$cluster_name\";\n";


### PR DESCRIPTION
## Use case

@JAlvarezJarreta complained that guiHive was unable to display his pipeline. We found that this was caused by the database name having a dot in it. `generate_graph.pl` also fails.

He found the issue on master. Here is the fix for version 2.4, which I will have to merge and adapt to the later branches, but there *will* be some conflicts as this part of the code has changed.

## Description

My fix is to quote the _subgraph_ names and remove dots from internal node names (I couldn't find how to quote these, and anyway this is only the internal name - the label works fine).

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No. There are no tests for generate_graph.pl on 2.4 . These were added on 2.5 only.
I seem to recall that the 2.4 graph generation cannot be reliably configured from the test suite and the host configuration can "leak" into the output of graphviz, making the tests a bit random.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
