### PR TITLE
Various Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
     - cpanm -nq local::lib
     - eval "$(perl -Mlocal::lib=${HOME}/deps)"
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
+    - export PERL5LIB=$PWD/bioperl-live:$PERL5LIB
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"
     - export PATH=$PWD:$PATH
@@ -56,6 +57,7 @@ before_install:
     - mvn -Dmaven.repo.local=$HOME/deps/maven clean
     - mvn -Dmaven.repo.local=$HOME/deps/maven -Dmaven.test.skip=true package
     - cd ../..
+    - export PERL5LIB=$PWD/modules:$PERL5LIB
 
 install:
     - cpanm -v --installdeps --with-recommends --notest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_install:
     - sqlite3 --version
     - env
     - cd wrappers/java
-    - mvn clean
-    - mvn package
+    - mvn -Dmaven.repo.local=$HOME/deps/maven clean
+    - mvn -Dmaven.repo.local=$HOME/deps/maven package
     - cd ../..
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_install:
     - export PERL5LIB=$PWD/bioperl-live:$PERL5LIB
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"
-    - export PATH=$PWD:$PATH
     - export EHIVE_HOME=$PWD
     - cd ../
     - wget https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
     - env
     - cd wrappers/java
     - mvn -Dmaven.repo.local=$HOME/deps/maven clean
-    - mvn -Dmaven.repo.local=$HOME/deps/maven package
+    - mvn -Dmaven.repo.local=$HOME/deps/maven -Dmaven.test.skip=true package
     - cd ../..
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,12 @@ before_install:
     - export PERL5LIB=$PWD/bioperl-live:$PERL5LIB
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"
-    - export EHIVE_HOME=$PWD
     - cd ../
     - wget https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz
     - tar xvzf openjdk-12.0.1_linux-x64_bin.tar.gz
     - export JAVA_HOME=$PWD/jdk-12.0.1
     - export PATH=$JAVA_HOME/bin:$PATH
-    - cd $EHIVE_HOME
+    - cd ensembl-hive
     - ls $JAVA_HOME
     - java -version
     - javac -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,13 @@ addons:
     - maven
     - graphviz
 
+cache:
+  directories:
+    - $HOME/deps
+
 before_install:
+    - cpanm -nq local::lib
+    - eval "$(perl -Mlocal::lib=${HOME}/deps)"
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ addons:
     - maven
     - graphviz
 
+# Dependencies that are brought by a system smart enough to reuse existing
+# files (e.g. CPAN and maven) are cached between builds under $HOME/deps.
+# Other dependencies are under $PWD/deps and *not* cached.
 cache:
   directories:
     - $HOME/deps
@@ -34,16 +37,17 @@ cache:
 before_install:
     - cpanm -nq local::lib
     - eval "$(perl -Mlocal::lib=${HOME}/deps)"
+    - mkdir deps
+    - cd deps
     - git clone --branch v1.6.x --depth 1 https://github.com/bioperl/bioperl-live
     - export PERL5LIB=$PWD/bioperl-live:$PERL5LIB
     - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
     - mysql -hlocalhost -utravis -e "SET GLOBAL sql_mode = 'TRADITIONAL'"
-    - cd ../
     - wget https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz
     - tar xvzf openjdk-12.0.1_linux-x64_bin.tar.gz
     - export JAVA_HOME=$PWD/jdk-12.0.1
     - export PATH=$JAVA_HOME/bin:$PATH
-    - cd ensembl-hive
+    - cd ..
     - ls $JAVA_HOME
     - java -version
     - javac -version
@@ -61,6 +65,8 @@ install:
     - cpanm -v --installdeps --with-recommends --notest .
     - cpanm -n Devel::Cover::Report::Coveralls
     - cpanm -n Devel::Cover::Report::Codecov
+    - ls $HOME/deps
+    - ls $PWD/deps
 
 script: "./scripts/dev/travis_run_tests.sh"
 

--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -637,7 +637,7 @@ sub all_source_files {
   my @starting_dirs = @_;
   my @files;
   my @dirs = @starting_dirs;
-  my %excluded_dir = map {$_ => 1} qw(_build build target .git __pycache__ bioperl-live cover_db);
+  my %excluded_dir = map {$_ => 1} qw(_build build target .git __pycache__ bioperl-live cover_db deps);
   while ( my $file = shift @dirs ) {
     if ( -d $file ) {
       opendir my $dir, $file or next;

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-export PERL5LIB=$PWD/bioperl-live:$PWD/modules:$PWD/deps
+export PERL5LIB=$PWD/bioperl-live:$PWD/modules
 export TEST_AUTHOR=$USER
 
 COVERALLS="false"

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -34,7 +34,7 @@ rt=$?
 
 (cd wrappers/python3; python3 -m unittest -v eHive.Process)
 rtp=$?
-(cd wrappers/java; mvn -Dmaven.repo.local=$HOME/deps/maven test)
+(cd wrappers/java; mvn "-Dmaven.repo.local=$HOME/deps/maven" test)
 rtj=$?
 
 if [[ ($rt -eq 0) && ($rtp -eq 0) && ($rtj -eq 0) ]]; then

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 
-export PERL5LIB=$PWD/bioperl-live:$PWD/modules:$HOME/deps/lib/perl5
 export TEST_AUTHOR=$USER
 
 COVERALLS="false"

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -26,7 +26,7 @@ fi
 
 echo "Running test suite"
 if [ "$COVERALLS" = 'true' ]; then
-  PERL5OPT="-MDevel::Cover=+ignore,bioperl,+ignore,/usr/bin/psql,+ignore,$HOME/perl5,-db,$PWD/cover_db/" prove -rv t
+  PERL5OPT="-MDevel::Cover=+ignore,deps,+ignore,/usr/bin/psql,+ignore,/home/travis/perl5,-db,$PWD/cover_db/" prove -rv t
 else
   prove -r t
 fi

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -35,7 +35,7 @@ rt=$?
 
 (cd wrappers/python3; python3 -m unittest -v eHive.Process)
 rtp=$?
-(cd wrappers/java; mvn test)
+(cd wrappers/java; mvn -Dmaven.repo.local=$HOME/deps/maven test)
 rtj=$?
 
 if [[ ($rt -eq 0) && ($rtp -eq 0) && ($rtj -eq 0) ]]; then

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-export PERL5LIB=$PWD/bioperl-live:$PWD/modules
+export PERL5LIB=$PWD/bioperl-live:$PWD/modules:$HOME/deps/lib/perl5
 export TEST_AUTHOR=$USER
 
 COVERALLS="false"


### PR DESCRIPTION
## Use case

Some recent Travis builds on `version/2.5` seem to have been stopped because of the inability of downloading maven packages. The hope is that by caching those, the packages won't have to be downloaded and the builds will be faster too.

## Description

I have backported the commits made on `master` about the Travis build. I have added a few more commits to tidy up the configuration of Travis

## Possible Drawbacks

This branch can't be straightforwardly merged into `master`, _git_ reports conflicts 

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

N/A