### PR TITLE
Line returns in die/warn statements

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/DBAdaptor.pm
@@ -93,7 +93,7 @@ sub new {
             if( scalar(@$dbas) == 1 ) {
                 $self = $dbas->[0];
             } elsif( @$dbas ) {
-                warn "The registry contains multiple entries for '$reg_alias', please prepend the reg_alias with the desired type";
+                warn "The registry contains multiple entries for '$reg_alias', please prepend the reg_alias with the desired type\n";
             }
         }
 

--- a/modules/Bio/EnsEMBL/Hive/Process.pm
+++ b/modules/Bio/EnsEMBL/Hive/Process.pm
@@ -633,6 +633,7 @@ sub complete_early {
         $self->input_job->autoflow(0);
     }
     $self->input_job->incomplete(0);
+    $msg .= "\n" unless $msg =~ /\n$/;
     die $msg;
 }
 

--- a/modules/Bio/EnsEMBL/Hive/URLFactory.pm
+++ b/modules/Bio/EnsEMBL/Hive/URLFactory.pm
@@ -136,7 +136,7 @@ sub fetch {
             );
         }
     } else {
-        warn "Could not parse URL '$url'";
+        warn "Could not parse URL '$url'\n";
     }
     return;
 }

--- a/modules/Bio/EnsEMBL/Hive/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Config.pm
@@ -96,7 +96,7 @@ sub load_from_json {
         
         return $perl_hash;
     } else {
-        warn "Can't read from '$filename'";
+        warn "Can't read from '$filename'. Configuration file not loaded\n";
 
         return undef;
     }


### PR DESCRIPTION
## Use case

Carla noticed that the error message she gets when doing `complete_early` includes `at /path/to/Hive/Process.pm line 638`. That's because her message was not ending with `\n`.
I think the module and line numbers are not useful. The purpose of `die` is to break out of the current `eval` and what matters is the user's message.

Similarly, I have changed a few `warn` statements to hide the location.

## Description

Just added `\n` where / when needed

## Possible Drawbacks

Do people find this information useful ?

## Testing

_Have you added/modified unit tests to test the changes?_

No

_Have you run the entire test suite and no regression was detected?_

Yes