### PR TITLE
bugfix: dbID is not set to -1 in standaloneJob any more

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
@@ -247,7 +247,7 @@ sub fetch_input {
     # Check whether the current database has been restored from a snapshot.
     # If it is the case, we shouldn't re-dump and overwrite the file.
     # We also check here the value of the "skip_dump" parameter
-    my $completion_signature = sprintf('dump_%d_restored', $self->input_job->dbID < 0 ? 0 : $self->input_job->dbID);
+    my $completion_signature = sprintf('dump_%d_restored', defined $self->input_job->dbID ? $self->input_job->dbID : 0);
 
     if ($self->param('skip_dump') or $self->param($completion_signature)) {
         # A command that always succeeds


### PR DESCRIPTION
## Use case

This bug is not causing any errors, but Perl is issuing some warnings ("unitialized value in lt", "unitialized value in sprintf") in standaloneJob context. I'd like to avoid those warnings.

## Description

The dbID used to be -1 in standaloneJob context on version/2.4, but was changed to _undef_ on version/2.5. This Runnable should have been updated at the same time.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_Have you run the entire test suite and no regression was detected?_

Yes