### PR TITLE
Test interface: show the content of the events with diag

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -104,6 +104,9 @@ sub standaloneJob {
 
     my $input_id = stringify($param_hash);
 
+    local $Data::Dumper::Terse = 1;
+    local $Data::Dumper::Sortkeys = 1;
+
     # When a list of events is given, it must match exactly what the
     # Runnable does (no missing / extra events, etc)
     my $_test_event = sub {
@@ -112,15 +115,16 @@ sub standaloneJob {
             my $expects = shift @$events_to_test;
             my $expected_type = shift @$expects;
             if ($triggered_type ne $expected_type) {
-                fail("Got a $triggered_type event but was expecting $expected_type\nEvent payload: " . stringify(\@got));
+                fail("Got a $triggered_type event but was expecting $expected_type");
+                diag "Got: " . Dumper([@_]);
             } elsif ($triggered_type eq 'WARNING') {
-                _compare_job_warnings(\@got, $expects);
+                _compare_job_warnings(\@got, $expects) or diag "Got: " . Dumper([@_]);
             } else {
-                _compare_job_dataflows(\@got, $expects);
+                _compare_job_dataflows(\@got, $expects) or diag "Got: " . Dumper([@_]);
             }
         } else {
             fail("event-stack is empty but the job emitted an event");
-            print Dumper([@_]);
+            diag "Got: " . Dumper([@_]);
         }
     };
 
@@ -150,7 +154,7 @@ sub standaloneJob {
 
         if ($expected_events) {
             ok(!scalar(@$events_to_test), 'no untriggered events');
-            diag("Did not receive: " . stringify($events_to_test)) if scalar(@$events_to_test);
+            diag("Did not receive: " . Dumper($events_to_test)) if scalar(@$events_to_test);
         }
     }
 }


### PR DESCRIPTION
## Use case

When writing unit-tests for Runnables, it is useful to see the exact events generated by the Runnable in order to copy-paste them. It also helps spotting the differences between what's expected and what's generated without having to bring `Test::Differences` in

## Description

I added several calls to `diag`

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

We don't have unit-tests for the test interface, but I've used the new functionality to write new unit-tests for Compara

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

All good