### PR TITLE
Misc. changes re. PostgreSQL

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisJobAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/AnalysisJobAdaptor.pm
@@ -87,8 +87,10 @@ sub default_overflow_limit {
 =head2 job_status_cast
 
   Example     : $job_adaptor->job_status_cast();
-  Description : Returns a job-status expression that the SQL driver understands.
-                This is needed for PostgreSQL
+  Description : Changes the type of the expression to the type of the
+                job-status ENUM.
+                This is needed for CASE expressions in PostgreSQL which
+                otherwise default to returning a string.
   Returntype  : String
   Exceptions  : none
 
@@ -948,7 +950,7 @@ sub unblock_jobs_for_analysis_id {
 
         my $sql2 = qq{
           UPDATE job j
-             SET status=}.$self->job_status_cast("'READY'").qq{
+             SET status='READY'
            WHERE $analyses_filter AND j.status = 'SEMAPHORED'
         };
         $self->dbc->do($sql2);
@@ -971,7 +973,7 @@ sub unblock_jobs_for_analysis_id {
 
         my $sql2 = qq{
           UPDATE job
-             SET status=}.$self->job_status_cast("'READY'").qq{
+             SET status='READY'
            WHERE $analyses_filter AND status = 'SEMAPHORED'
         };
         $self->dbc->do($sql2);
@@ -1012,14 +1014,14 @@ sub discard_jobs_for_analysis_id {
 
     my $sql2 = qq{
         UPDATE job
-        SET status = }.$self->job_status_cast("'DONE'").qq{
+        SET status = 'DONE'
         WHERE controlled_semaphore_id = ?
               AND $analyses_filter $status_filter
     };
 
     my $sql3 = qq{
         UPDATE job
-        SET status = }.$self->job_status_cast("'DONE'").qq{
+        SET status = 'DONE'
         WHERE controlled_semaphore_id IS NULL
               AND $analyses_filter $status_filter
     };


### PR DESCRIPTION
## Use case

There has been some transient Travis failures recently, and they seem to arise from `t/03.scripts/beekeeper_reset.t`. The problem is that runWorker doesn't always run the jobs in the same order, so the job statuses don't match what the test expects.
See https://travis-ci.org/Ensembl/ensembl-hive/jobs/614039653 and https://travis-ci.org/Ensembl/ensembl-hive/jobs/613529841

## Description

Instead of running a single generic runWorker command, run specific jobs in a certain order.

At the same time, I simplify the AnalysisJob adaptor a little bit, as we don't need to always CAST the job status in PostreSQL. It is only needed for CASE expressions, as they otherwise default to a being a string.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes