### PR TITLE
Misc. changes re. testing the text outputs

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils/URL.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/URL.pm
@@ -92,7 +92,7 @@ sub parse {
             }
 
             if($exception_from_OLD_format) {
-                warn "\nOLD URL parser thinks you are using the NEW URL syntax for a remote $query_params->{'object_type'}, so skipping it (it may be wrong!)\n";
+                warn "OLD URL parser thinks you are using the NEW URL syntax for a remote $query_params->{'object_type'}, so skipping it (it may be wrong!)\n";
             } else {
                 my $unambig_url     = hash_to_unambig_url( $url_parts_hash );
 
@@ -146,7 +146,7 @@ sub parse {
             }
 
             if($exception_from_NEW_format) {
-                warn "\nNEW URL parser thinks you are using the OLD URL syntax for a remote $query_params->{'object_type'}, so skipping it (it may be wrong!)\n";
+                warn "NEW URL parser thinks you are using the OLD URL syntax for a remote $query_params->{'object_type'}, so skipping it (it may be wrong!)\n";
             } else {
                 my $unambig_url     = hash_to_unambig_url( $url_parts_hash );
 
@@ -166,16 +166,16 @@ sub parse {
         if(stringify($old_parse) eq stringify($new_parse)) {
             return $new_parse;
         } else {
-            warn "\nThe URL '$url' can be parsed ambiguously:\n\t".stringify($old_parse)."\nvs\n\t".stringify($new_parse)."\n). Using the OLD parser at the moment.\nPlease change your URL to match the new format if you see weird behaviour\n\n";
+            warn "The URL '$url' can be parsed ambiguously:\n\t".stringify($old_parse)."\nvs\n\t".stringify($new_parse)."\n). Using the OLD parser at the moment.\nPlease change your URL to match the new format if you see weird behaviour\n\n";
             return $old_parse;
         }
     } elsif($new_parse) {
         return $new_parse;
     } elsif($old_parse) {
-        warn "\nThe URL '$url' only works with the old parser, please start using the new syntax as the old parser will soon be deprecated\n\n";
+        warn "The URL '$url' only works with the old parser, please start using the new syntax as the old parser will soon be deprecated\n\n";
         return $old_parse;
     } else {
-        warn "\nThe URL '$url' could not be parsed, please check it\n";
+        warn "The URL '$url' could not be parsed, please check it\n";
         return;
     }
 }

--- a/t/01.utils/url.t
+++ b/t/01.utils/url.t
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Warn;
 use Data::Dumper;
 
 BEGIN {
@@ -75,7 +76,11 @@ BEGIN {
 {       # OLD style local table URL:
     my $url = ':////final_result';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warning_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        qr/The URL '.*' only works with the old parser/,
+        'Warned the user';
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -86,7 +91,11 @@ BEGIN {
 {       # OLD style (local) accu URL:
     my $url = ':////accu?partial_product={digit}';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warning_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        qr/The URL '.*' only works with the old parser/,
+        'Warned the user';
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -98,7 +107,14 @@ BEGIN {
 {       # OLD style foreign analysis URL:
     my $url = 'mysql://who:secret@where.co.uk:12345/other_pipeline/analysis?logic_name=foreign_analysis';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warnings_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        [
+            qr/NEW URL parser thinks you are using the OLD URL syntax for a remote Analysis, so skipping it/,
+            qr/The URL '.*' only works with the old parser/,
+        ],
+        'Warned the user';
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -115,7 +131,14 @@ BEGIN {
 {       # OLD style foreign table URL (due to mysql/pgsql database/table naming rules, should stay in OLD format only)
     my $url = 'pgsql://user:password@hostname/databasename/foreign_table';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warnings_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        [
+            qr/NEW URL parser thinks you are using the OLD URL syntax for a remote NakedTable, so skipping it/,
+            qr/The URL '.*' only works with the old parser/,
+        ],
+        'Warned the user';
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -132,7 +155,15 @@ BEGIN {
 {       # OLD style sqlite foreign table URL (due to the 'insertion_method' parameter defined, should stay in OLD format only)
     my $url = 'sqlite:///databasename/foreign_table?insertion_method=REPLACE';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warnings_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        [
+            qr/NEW URL parser thinks you are using the OLD URL syntax for a remote NakedTable, so skipping it/,
+            qr/The URL '.*' only works with the old parser/,
+        ],
+        'Warned the user';
+
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -244,7 +275,13 @@ BEGIN {
 {       # NEW style foreign table URL with a two-part path:
     my $url = 'sqlite:///other_directory/other_pipeline?table_name=foreign_table';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warning_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        qr/OLD URL parser thinks you are using the NEW URL syntax for a remote NakedTable/,
+        'Warned the user';
+
+    ok($url_hash, "parser returned something for $url");
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );
@@ -260,7 +297,13 @@ BEGIN {
 {       # OLD style sqlite foreign table URL  ...or... NEW style bipartite sqlite path
     my $url = 'sqlite:///databasename/foreign_table';
 
-    my $url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url );
+    my $url_hash;
+    warning_like
+        {$url_hash = Bio::EnsEMBL::Hive::Utils::URL::parse( $url ) }
+        qr/The URL '.*' can be parsed ambiguously/,
+        'Warned the user';
+
+    ok($url_hash, "parser returned something for $url");
 
     ok($url_hash, "parser returned something for $url");
     isa_ok( $url_hash, 'HASH' );

--- a/t/02.api/create_drop_database.t
+++ b/t/02.api/create_drop_database.t
@@ -38,7 +38,7 @@ foreach my $test_url (@$ehive_test_pipeline_urls) {
     my $dbc = Bio::EnsEMBL::Hive::DBSQL::DBConnection->new(-url => $test_url);
 
     # To ensure we start with the database being absent
-    system(@{ $dbc->to_cmd(undef, undef, undef, 'DROP DATABASE') });
+    system(@{ $dbc->to_cmd(undef, undef, undef, 'DROP DATABASE IF EXISTS') });
 
     run_sql_on_db($test_url, 'DROP DATABASE IF EXISTS', "Don't complain if asked to drop a database that doesn't exist");
     if ($dbc->driver eq 'sqlite') {


### PR DESCRIPTION
## Use case

My motivation was to make the output of `prove -r t` clearer by removing spurious eHive messages. 

## Description

I'm achieving that by capturing stdout/stderr accordingly and checking that they are as expected. I also check that eHive issues warnings as expected (e.g. URL parsing)

## Possible Drawbacks

When changing some error messages we'll have to change the unit-test as well.
There are still some tests that will have stuff printed to stderr and that I haven't been able to silence / test yet.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes