### PR TITLE
Silence codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,8 @@ coverage:
   status:
     project:
       default:
+        # Don't report failures on pull-requests
+        informational: true
   notify:
     slack:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,10 +3,8 @@ coverage:
   status:
     project:
       default:
-        threshold: 1%
   notify:
     slack:
       default:
         url: secret:LW+i/4NzE9beqqJetobJEJP8GowY1eHWyaiIJM7BB5ZMET5oak4rsGK9zznYFaLQ0jncm46ES7b+aDshLPEMyYp+fvtM/QL0C1+n+nP1tQhzt+kQeFdj5eZA2VBm5qYQq7FuaS1p7PpWEY1EeuQkFWNWQMKNDkeO/ZSrqaiWRUQ=
-        threshold: 1%
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
-codecov:
-  branch: master
 
 coverage:
   status:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,5 @@
 codecov:
   branch: master
-  notify:
-    after_n_builds: 1
 
 coverage:
   status:


### PR DESCRIPTION
## Use case

I personally find the codecov messages too invasive. Unlike coveralls, they cannot be controlled from the codecov website, it has to be set in `codecov.yml`
This is not my first attempt. I hope this one will work ! We'll quickly see on this PR

## Description

I change `codecov.yml` to disable the comments. codecov should still notify if the coverage drops by more than 1%. I could test this by doing a fake PR that removes most of the test suite.

## Possible Drawbacks

Code coverage stats will be less visible

## Testing

This PR will test things live