### PR TITLE
[ENSCORESW-3350] update expected output in lsf.t

### DIFF
--- a/t/04.meadow/lsf.t
+++ b/t/04.meadow/lsf.t
@@ -149,7 +149,7 @@ lives_ok( sub {
 
 my $expected_bacct = {
     '2581807[1]' => {
-        'died' => '2015-11-26 14:25:12',
+        'died' => '2020-11-26 14:25:12',
         'pending_sec' => '147',
         'exception_status' => 'underrun',
         'cause_of_death' => undef,
@@ -160,7 +160,7 @@ my $expected_bacct = {
         'swap_megs' => 144
     },
     '2581801[48]' => {
-        'died' => '2015-11-26 14:25:16',
+        'died' => '2020-11-26 14:25:16',
         'pending_sec' => '196',
         'exception_status' => 'underrun',
         'mem_megs' => 50,
@@ -176,7 +176,7 @@ my $expected_bacct = {
         'pending_sec' => '2',
         'exception_status' => 'underrun',
         'swap_megs' => 218,
-        'died' => '2015-12-02 13:53:29',
+        'died' => '2020-12-02 13:53:29',
         'cause_of_death' => 'MEMLIMIT',
         'exit_status' => 'exit/TERM_MEMLIMIT',
         'mem_megs' => 102
@@ -191,8 +191,8 @@ lives_and( sub {
 }, 'Can call bacct on process_ids');
 
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-l -C 2015/10/11/12:23,2015/12/12/23:58 -u kb3';
-    my $h = $lsf_meadow->get_report_entries_for_time_interval('2015-10-11 12:23:45', '2015-12-12 23:56:59', 'kb3');
+    local $ENV{EHIVE_EXPECTED_BACCT} = '-l -C 2020/10/11/12:23,2020/12/12/23:58 -u kb3';
+    my $h = $lsf_meadow->get_report_entries_for_time_interval('2020-10-11 12:23:45', '2020-12-12 23:56:59', 'kb3');
     is_deeply($h, $expected_bacct, 'Got bacct output');
 }, 'Can call bacct on a date range');
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

Makes expected output in 04.meadow/lsf.t match the actual output of Meadow/LSF.pm date parsing so that the test suite passes again.

## Description

LSF bacct outputs dates without a year on them. Therefore, the LSF meadow has to make a best guess of the year based on the date and day of the week when parsing the output. This causes issues every few years when the day+date match up with a new year.

This fix updates the expected year in the LSF Meadow test plan to match the new guessed year in 2020.

More discussion in ENSCORESW-3350

## Possible Drawbacks

We will have to update the test again in 2025 if a more robust year-guessing system is not updated in the meantime.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_

No regression
