### PR TITLE
Don't use SharedSecrets, but instead directly call a private constructor

### DIFF
--- a/wrappers/java/src/main/java/org/ensembl/hive/RunWrapper.java
+++ b/wrappers/java/src/main/java/org/ensembl/hive/RunWrapper.java
@@ -23,8 +23,6 @@ import java.lang.reflect.Constructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jdk.internal.access.SharedSecrets;
-
 /**
  * Main class for running a hive worker in Java
  * 
@@ -78,11 +76,11 @@ public class RunWrapper {
 		Constructor<?> ctor = clazz.getConstructor();
 //		log.debug("Initializing runnable module " + clazz.getName() + " from " + args[1] + " and " + args[2]);
 
-        FileDescriptor inputDescriptor = new FileDescriptor();
-        SharedSecrets.getJavaIOFileDescriptorAccess().set(inputDescriptor, Integer.parseInt(args[1]));
-
-        FileDescriptor outputDescriptor = new FileDescriptor();
-        SharedSecrets.getJavaIOFileDescriptorAccess().set(outputDescriptor, Integer.parseInt(args[2]));
+		Constructor<FileDescriptor> fdctor = FileDescriptor.class.getDeclaredConstructor(Integer.TYPE);
+		fdctor.setAccessible(true);
+		FileDescriptor inputDescriptor = fdctor.newInstance(Integer.parseInt(args[1]));
+		FileDescriptor outputDescriptor = fdctor.newInstance(Integer.parseInt(args[2]));
+		fdctor.setAccessible(false);
 
 		BaseRunnable runnable = (BaseRunnable) (ctor.newInstance());
         runnable.setFileDescriptors(inputDescriptor, outputDescriptor);

--- a/wrappers/java/wrapper
+++ b/wrappers/java/wrapper
@@ -53,7 +53,7 @@ elif [ "$action" == "run" ]; then
 
 	#echo "Running in $PWD:" java -cp "lib/*" org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
 
-	exec java -cp target/eHive-*-jar-with-dependencies.jar --add-exports java.base/jdk.internal.access=ALL-UNNAMED org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
+	exec java -cp target/eHive-*-jar-with-dependencies.jar --add-opens java.base/java.io=ALL-UNNAMED org.ensembl.hive.RunWrapper "$module" "$fd_in" "$fd_out" "$debug"
 else
 	echo "Command-line error: No mode provided"
 	echo "$usage"


### PR DESCRIPTION
## Requirements

## Use case

When reinstalling my laptop I realised that none of the Java versions compatible with eHive (i.e. 12+) are LTS, and it won't be the case for another 18 months, see https://en.wikipedia.org/wiki/Java_version_history

The problem comes from using a package named `SharedSecrets` which provides a way of referring to a file descriptor by integer (such integers can't otherwise be set in Java). The package has had multiple names through time
- `sun.misc.SharedSecrets` in Oracle JDK 8
- `jdk.internal.misc.SharedSecrets` in OpenJDK <12
- `jdk.internal.access.SharedSecrets` in OpenJDK 12+

In #104 #109 #111 we decided with @mira13 to use the most recent denomination, but I didn't realise there wouldn't be any LTS release covering it.

## Description

I have found another hack. Using reflection, we can find the `FileDescriptor` constructor that takes an integer, unset its _private_ attribute and invoke it.

:warning: Note that these files have changed on master, and there **will** be a merge conflict. I already have the correct commit for master on my laptop. Let me know how you want to proceed

## Possible Drawbacks

None, the solution seems "universal"

## Testing

_Have you added/modified unit tests to test the changes?_

Already covered by tests. JDK12 (or 13?) on Travis, JDK11 on my laptop. I believe it would work on JDK8 as well, but can't try it

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes