### PR TITLE
Better detection of the process being killed

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/SystemCmd.pm
@@ -128,15 +128,17 @@ sub write_output {
     my $stderr = $self->param('stderr');
     my $flat_cmd = $self->param('flat_cmd');
 
-    if ($return_value and not ($return_value >> 8)) {
-        # The job has been killed. The best is to wait a bit that LSF kills
+    # Lower 8 bits indicate the process has been killed and did not complete.
+    if ($return_value & 255) {
+        # It can happen because of a MEMLIMIT / RUNLIMIT, which we
+        # know are not atomic. The best is to wait a bit that LSF kills
         # the worker too
         sleep 30;
-        # If we reach this point, perhaps it was killed by a user
+        # If we reach this point, it was killed for another reason.
         die sprintf( "'%s' was killed with code=%d\nstderr is: %s\n", $flat_cmd, $return_value, $stderr);
 
     } elsif ($return_value) {
-        # "Normal" process exit with a non-zero code
+        # "Normal" process exit with a non-zero code (in the upper 8 bits)
         $return_value >>= 8;
 
         # We create a dataflow event depending on the exit code of the process.


### PR DESCRIPTION
## Use case

I've found cases where the process was being killed by LSF (MEMLIMIT) but there was also an exit code in the upper 8 bits. In those cases, we still want to go through the MEMLIMIT path.

## Description

I changed the condition from "not having data in the upper 8 bits) to "having data in lower 8 bits".
Note that because this module has frequently changed, it won't be a straightforward merge. The equivalent commits are:
- [version 2.4](https://github.com/Ensembl/ensembl-hive/commit/390909d31c7821f0d08e6016990a4778b983a83a)
- [version 2.5](https://github.com/Ensembl/ensembl-hive/commit/f86a618117276227c183a5298a3251ffa54c7530)

## Possible Drawbacks

None envisaged

## Testing

_Have you added/modified unit tests to test the changes?_

Not sure how to test this. Most of the time a kill results in only the lower 8 bits having some data

_Have you run the entire test suite and no regression was detected?_

Yes. OK