### PR TITLE
Improved big red button

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -421,6 +421,9 @@ sub kill_all_workers {
                 }
             }
         }
+        else {
+            $kill_status = 'could not kill, running under user ' . $worker->meadow_user;
+        }
 
         print 'Killing worker ' . $worker->dbID() . ': '
             . $worker->toString( 1 ) . " -> $kill_status \n";

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -423,7 +423,7 @@ sub kill_all_workers {
         }
 
         print 'Killing worker ' . $worker->dbID() . ': '
-            . $worker->toString( 1 ) . "\n";
+            . $worker->toString( 1 ) . " -> $kill_status \n";
     }
 
     return;

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -390,6 +390,7 @@ sub register_worker_death {
 sub kill_all_workers {
     my ( $self, $valley ) = @_;
 
+    my $this_meadow_user = whoami();
     my $all_workers_considered_alive = $self->fetch_all( "status!='DEAD'" );
     foreach my $worker ( @{ $all_workers_considered_alive } ) {
         my $kill_status;
@@ -403,7 +404,7 @@ sub kill_all_workers {
         elsif ( ! $meadow->can('kill_worker') ) {
             $kill_status = 'killing workers not supported by the meadow';
         }
-        else {
+        elsif ( $worker->meadow_user eq $this_meadow_user ) {  # if I'm actually allowed to kill the worker...
             # The actual termination of a worker might well be asynchronous
             # but at least we check for obvious problems, e.g. insufficient
             # permissions to execute a kill.

--- a/modules/Bio/EnsEMBL/Hive/Queen.pm
+++ b/modules/Bio/EnsEMBL/Hive/Queen.pm
@@ -416,6 +416,9 @@ sub kill_all_workers {
                 $kill_status = 'requested successfully';
                 $worker->cause_of_death( 'KILLED_BY_USER' );
                 $self->register_worker_death( $worker );
+                if ( $worker->status ne 'SUBMITTED' ) {             # There is no worker_temp_directory before specialization
+                    $meadow->cleanup_temp_directory( $worker );
+                }
             }
         }
 


### PR DESCRIPTION
## Use case

Found two issues when calling beekeeper with `-big_red_button`.
1. beekeeper tried to kill workers of another user
2. beekeeper didn't clean up the temporary directories

## Description

Both issues are quite straightforward to fix

## Possible Drawbacks

None envisaged

## Testing

_Have you added/modified unit tests to test the changes?_

1. Can't have more than 1 user in the test-suite.
2. About the temp directory, I would have to change the `longrunning` analysis of the example pipeline `LongWorker` to make it write somewhere. Can I do that ? \
By the way, this example pipeline is only referenced in the test-suite (introduced in b98c8b891df5d962934fc4b711b893170ff56727) and I don't think it has any pedagogical value (unlike `CompressFiles`, `MemlimitTest`, etc). Would you mind if I move it to `t/10.pipeconfig/TestPipeConfig` and change the analysis ?

_Have you run the entire test suite and no regression was detected?_

Yes