### PR TITLE
Account for time slippage on Travis

### DIFF
--- a/t/05.runnabledb/dummy.t
+++ b/t/05.runnabledb/dummy.t
@@ -24,24 +24,13 @@ use Time::HiRes qw(time);
 
 use Bio::EnsEMBL::Hive::Utils::Test qw(standaloneJob);
 
-my $min_overhead;
-
-for (1..10) {
-    my $t = time();
-    standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::Dummy', {
-        'take_time' => 0,
-    });
-    my $d = time() - $t;
-    $min_overhead = $d if (not defined $min_overhead) || ($d < $min_overhead);
-}
-
 my $wait = 10;
 my $t = time();
 standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::Dummy', {
     'take_time' => $wait,
 });
 my $d = time() - $t;
-# We allow the runnable to be 5 times faster than the fastest attempt so far
-cmp_ok($d, '>=', $wait+$min_overhead/5, 'The "take_time" parameter made the runnable sleep a bit');
+
+cmp_ok($d, '>=', $wait, 'The "take_time" parameter made the runnable sleep');
 
 done_testing();

--- a/t/05.runnabledb/dummy.t
+++ b/t/05.runnabledb/dummy.t
@@ -31,6 +31,11 @@ standaloneJob('Bio::EnsEMBL::Hive::RunnableDB::Dummy', {
 });
 my $d = time() - $t;
 
+# Correct for Travis' built-in time machine
+if ($ENV{'TRAVIS'}) {
+    $wait -= 1;
+}
+
 cmp_ok($d, '>=', $wait, 'The "take_time" parameter made the runnable sleep');
 
 done_testing();


### PR DESCRIPTION
## Use case

When running on Travis, `sleep(10)` may sleep for less than 10 seconds.
We have no explanation for this, so when it happens we simply restart the
job.

```
#   Failed test 'The "take_time" parameter made the runnable sleep a bit'
#   at t/05.runnabledb/dummy.t line 49.
#     '9.66858005523682'
#         >=
#     '10.0015641689301'
# Looks like you failed 1 test of 12.
```

## Description

`dummy.t` detects it is running on Travis and expects that 9 seconds have
elapsed instead of 10. I think all the cases we have seen are > 9.5 seconds
so we should avoid most failures.

Note that I have also removed the estimation of the overhead. I (now) think
it is not needed in this Runnable. All that matters is that we slept
enough.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes
