### PR TITLE
In standaloneJob mode there is no need to query all meadows

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Scripts/StandaloneJob.pm
+++ b/modules/Bio/EnsEMBL/Hive/Scripts/StandaloneJob.pm
@@ -26,13 +26,18 @@ use warnings;
 use Bio::EnsEMBL::Hive::AnalysisJob;
 use Bio::EnsEMBL::Hive::GuestProcess;
 use Bio::EnsEMBL::Hive::HivePipeline;
+use Bio::EnsEMBL::Hive::Meadow::LOCAL;
 use Bio::EnsEMBL::Hive::Queen;
 use Bio::EnsEMBL::Hive::Utils ('load_file_or_module', 'destringify');
 use Bio::EnsEMBL::Hive::Utils::PCL;
+use Bio::EnsEMBL::Hive::Valley;
 
 
 sub standaloneJob {
     my ($module_or_file, $input_id, $flags, $flow_into, $language) = @_;
+
+    # Tell the Valley not to bother about the other meadows.
+    $Bio::EnsEMBL::Hive::Valley::_loaded_meadow_drivers = ['Bio::EnsEMBL::Hive::Meadow::LOCAL'],
 
     my $worker = Bio::EnsEMBL::Hive::Queen->create_new_worker(
 


### PR DESCRIPTION
## Use case

If you add the SLURM meadow to your PERL5LIB, you will notice some of its
debug statements when running stansaloneJob. It's because the constructor
of Valley calls `loaded_meadow_drivers` which lists and loads all the
available Meadow drivers.
I believe that's not necessary. In standaloneJob job the worker is pretty
much a fake one. Its purpose is to mimic the "real" execution of the job
(alongside a fake Role, a fake Analysis, a fake Job, etc) but that's all.
The Worker is not recorded anywhere, and the attributes that are pulled
from the Valley are not used anywhwere.

Anyway, I think standaloneJob shouldn't bother about all the meadows. It
represents a debugging task and as such should just assume to be running on
LOCAL.

## Description

The change sets the list of loaded drivers to LOCAL only, so that it is the
only Meadow considered by the Valley.

## Possible Drawbacks

None.

## Testing

_Have you added/modified unit tests to test the changes?_

No. The only way I could think of is to write a Meadow driver that doesn't
compile, add it to PERL5LIB, run standaloneJob, and expect it _not to
fail_. It feels a bit too much, what do you think ?

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Fine
