### PR TITLE
Don't attempt removing objects that haven't been stored

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm
@@ -416,6 +416,9 @@ sub remove {    # remove the object by primary_key
     my $self        = shift @_;
     my $object      = shift @_;
 
+    # the object hasn't actually been stored yet / in this database
+    return if(UNIVERSAL::can($object, 'adaptor') and (!$object->adaptor or $object->adaptor != $self));
+
     my $primary_key_constraint  = $self->primary_key_constraint( $self->slicer($object, $self->primary_key()) );
 
     return $self->remove_all( $primary_key_constraint );


### PR DESCRIPTION
## Use case

If you use a tweak that changes dataflows / wait_for rules when initialising the pipeline, e.g.
```
init_pipeline.pl Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMult_conf -pipeline_url $URL -tweak 'analysis[take_b_apart].flow_into=["part_multiply"]'
```
you will see this Perl warning
```
Use of uninitialized value in concatenation (.) or string at /home/matthieu/workspace/src/hive/2.4/modules/Bio/EnsEMBL/Hive/DBSQL/BaseAdaptor.pm line 387.
```

This is because when the pipeline is tweaked, it only exists in memory, not in the database, and the `flow_into` update works by 1) removing the previous dataflow targets and 2) adding the new ones. The previous targets not being stored, a warning is shown.

## Description

The fix is to return early in the `remove` method when the object hasn't been stored yet, which is detected by looking at the adaptor.

Note: the commit applies to the branches 2.2 and 2.3 as well, but these two branches don't have tweaks, and I don't know how to make this bug happen without tweaks _in usual conditions_ (you can still imagine a Runnable using the eHive API to store / remove data the same way, but I think it's unlikely).

## Possible Drawbacks

None envisaged

## Testing

_Have you added/modified unit tests to test the changes?_

There is no unit test for BaseAdaptor, and I'm not sure it's worth adding one just for this. Especially because the current code doesn't fail (the change is about avoiding a warning)

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

OK
