### PR TITLE
init_pipeline should check that dataflow targets are valid URLs

### DIFF
--- a/t/02.api/pipeconfig_parser.t
+++ b/t/02.api/pipeconfig_parser.t
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::More;
+use Test::Warn;
+
+use Bio::EnsEMBL::Hive::HivePipeline;
+use Bio::EnsEMBL::Hive::Utils::PCL;
+
+my $pipeline = Bio::EnsEMBL::Hive::HivePipeline->new();
+my ($analysis) = $pipeline->add_new_or_update('Analysis', logic_name => 'first'); 
+
+subtest 'dataflow', sub {
+
+    warnings_are {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_flow_into($pipeline, $analysis, [ 'first' ]);
+    } [], 'no warnings if the analysis exists';
+
+    warning_like {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_flow_into($pipeline, $analysis, [ 'oops_i_am_missing' ]);
+    } qr/WARNING: Could not find a local analysis named 'oops_i_am_missing' \Q(dataflow from analysis 'first')/, 'warning about missing analysis';
+
+    throws_ok {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_flow_into($pipeline, $analysis, [ '<oops_i_am_missing>' ]);
+    } qr/Could not parse the URL '<oops_i_am_missing>' .dataflow from analysis/, 'invalid URL';
+
+    warnings_are {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_flow_into($pipeline, $analysis, [ '?logic_name=oops_i_am_missing' ]);
+    } [], 'no warnings when using an analysis URL, even if it does not exist';
+
+    # Accumulators are accepted
+    warnings_are {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_flow_into($pipeline, $analysis, [ '?accu_name=oops_i_am_missing' ]);
+    } [], 'accu targets are accepted';
+};
+
+subtest 'wait_for', sub {
+
+    warnings_are {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_wait_for($pipeline, $analysis, [ 'first' ]);
+    } [], 'no warnings if the analysis exists';
+
+    warning_like {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_wait_for($pipeline, $analysis, [ 'oops_i_am_missing' ]);
+    } qr/WARNING: Could not find a local analysis 'oops_i_am_missing' to create a control rule \Q(in 'first')/, 'warning about missing analysis';
+
+    throws_ok {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_wait_for($pipeline, $analysis, [ '<oops_i_am_missing>' ]);
+    } qr/Could not parse the URL '<oops_i_am_missing>' to create a control rule/, 'invalid URL';
+
+    warnings_are {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_wait_for($pipeline, $analysis, [ '?logic_name=oops_i_am_missing' ]);
+    } [], 'no warnings when using an analysis URL, even if it does not exist';
+
+    throws_ok {
+        Bio::EnsEMBL::Hive::Utils::PCL::parse_wait_for($pipeline, $analysis, [ '?accu_name=oops_i_am_missing' ]);
+    } qr/ERROR: The URL '.*' does not refer to an Analysis/, 'accu targets are not accepted';
+};
+
+done_testing();
+


### PR DESCRIPTION
## Use case

`init_pipeline` accepts invalid URLs (e.g. URLs that can't be parse), meaning that the problem is revealed much later (when drawing the diagram or when the actual dataflow happens)

@CristiGuijarro was affected by this. In the PipeConfig she had something like
```
flow_into => [ 'a' => INPUT_PLUS() ],
```
i.e. an array-ref instead of an hash-ref. `init_pipeline` didn't complain and stored a dataflow rule on branch 1 for the target named `+` (which is the internal string to indicate `INPUT_PLUS`).

## Description

With this change, `init_pipeline` will check that the URLs are valid and die if they're not. The change being in Utils::PCL, `generate_graph.pl -pipeconfig` will benefit from it too.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

Yes. Note that the unit-test is directly testing Utils::PCL. The existing `t/10.pipeconfig/analysis_heir.t` has some equivalent tests but for init_pipeline. They're redundant but `t/10.pipeconfig/analysis_heir.t` checks that the error / warning bubbles up to the user.

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes