### PR TITLE
Test init_pipeline outside of the test process and drop the (partial) database if the initialisation fails

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -25,6 +25,7 @@ use warnings;
 no warnings qw( redefine );
 
 use Exporter;
+use Capture::Tiny 'tee_stderr';
 use Carp qw{croak};
 use File::Spec;
 use File::Temp qw{tempfile};
@@ -168,6 +169,8 @@ sub standaloneJob {
   Arg[4]      : (optional) Arrayref $tweaks. Tweaks to be applied to the database (as with the -tweak command-line option)
   Arg[5]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : init_pipeline(
                     'Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMultServer_conf',
                     $server_url,
@@ -218,6 +221,8 @@ sub init_pipeline {
   Arg[4]      : String $test_name (optional). The name of the test
   Arg[5]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Description : Generic method that can run any eHive script and check its return status
   Returntype  : None
   Exceptions  : TAP-style
@@ -232,10 +237,16 @@ sub _test_ehive_script {
     $flags ||= {};
     my @ext_args = ( defined($url) ? (-url => $url) : (), @$args );
 
-    my $rc = system($ENV{'EHIVE_ROOT_DIR'}.'/scripts/'.$script_name.'.pl', @ext_args);
+    my $rc;
+    my $stderr = tee_stderr {
+        $rc = system($ENV{'EHIVE_ROOT_DIR'}.'/scripts/'.$script_name.'.pl', @ext_args);
+    };
     if ($flags->{expect_failure}) {
         $test_name ||= $script_name.' fails'.(@ext_args ? ' with the command-line options: '.join(' ', @ext_args) : '');
         ok($rc, $test_name);
+        if (re::is_regexp($flags->{expect_failure})) {
+            like($stderr, $flags->{expect_failure}, 'error message as expected');
+        }
     } else {
         $test_name ||= 'Can run '.$script_name.(@ext_args ? ' with the command-line options: '.join(' ', @ext_args) : '');
         is($rc, 0, $test_name);
@@ -250,6 +261,8 @@ sub _test_ehive_script {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : runWorker($url, [ -can_respecialize => 1 ]);
   Description : Run a worker on the given pipeline in the current process.
                 The worker options have been divided in three groups: the ones affecting its specialization,
@@ -284,6 +297,8 @@ sub runWorker {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : $seed_pipeline($url, [$arg1, $arg2], 'Run seed_pipeline with two arguments');
   Description : Very generic function to run seed_pipeline on the given database with the given arguments
   Returntype  : None
@@ -306,6 +321,8 @@ sub seed_pipeline {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : beekeeper($url, [$arg1, $arg2], 'Run beekeeper with two arguments');
   Description : Very generic function to run beekeeper on the given database with the given arguments
   Returntype  : None
@@ -326,6 +343,8 @@ sub beekeeper {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : tweak_pipeline($url, [$arg1, $arg2], 'Run tweak_pipeline with two arguments');
   Description : Very generic function to run tweak_pipeline on the given database with the given arguments
   Returntype  : None
@@ -347,6 +366,8 @@ sub tweak_pipeline {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : generate_graph($url, [-output => 'lm_analyses.png'], 'Generate a PNG A-diagram');
   Description : Very generic function to run generate_graph.pl on the given database with the given arguments
   Returntype  : None
@@ -368,6 +389,8 @@ sub generate_graph {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : visualize_jobs($url, [-output => 'lm_jobs.png', -accu_values], 'Generate a PNG J-diagram with accu values');
   Description : Very generic function to run visualize_jobs.pl on the given database with the given arguments
   Returntype  : None
@@ -388,6 +411,8 @@ sub visualize_jobs {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : peekJob($url, [-job_id => 1], 'Check params for job 1');
   Description : Very generic function to run peekJob.pl on the given database with the given arguments
   Returntype  : None
@@ -409,6 +434,8 @@ sub peekJob {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : db_cmd($url, [-sql => 'DROP DATABASE'], 'Drop the database');
   Description : Very generic function to run db_cmd.pl on the given database with the given arguments
   Returntype  : None
@@ -430,6 +457,8 @@ sub db_cmd {
   Arg[3]      : String $test_name (optional). The name of the test
   Arg[4]      : (optional) Hashref $flags. Flags given to the text framework. Currently the only
                 key that is understood is "expect_failure" to reverse the expectation of the test.
+                It is primarily used as a boolean, but can be a regular expression to test the standard
+                error of the script.
   Example     : run_sql_on_db($url, 'INSERT INTO sweets (name, quantity) VALUES (3, 'Snickers')');
   Description : Execute an SQL command on the given database and test its execution. This expects the
                 command-line client to return a non-zero code in case of a failure.

--- a/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
+++ b/modules/Bio/EnsEMBL/Hive/Utils/Test.pm
@@ -199,20 +199,11 @@ sub init_pipeline {
         $url = (splice(@$options, $url_flag_index, 2))[1];
     }
 
-    local @ARGV = @$options;
-    unshift @ARGV, (-pipeline_url => $url, -hive_force_init => 1);
+    my @args = ($file_or_module, -pipeline_url => $url, -hive_force_init => 1);
+    push @args, @$options;
+    push @args, map {-tweak => $_} @$tweaks if $tweaks;
 
-    lives_ok(sub {
-        my $orig_unambig_url = Bio::EnsEMBL::Hive::Utils::URL::parse($url)->{'unambig_url'};
-        ok($orig_unambig_url, 'Given URL could be parsed');
-        my $returned_url = Bio::EnsEMBL::Hive::Scripts::InitPipeline::init_pipeline($file_or_module, $tweaks);
-        ok($returned_url, 'pipeline initialized on '.$returned_url);
-
-        my $returned_unambig_url = Bio::EnsEMBL::Hive::Utils::URL::parse($returned_url)->{'unambig_url'};
-            # Both $url and $returned_url MAY contain the password (if applicable for the driver) but can be missing the port number assuming a default
-            # Both $orig_unambig_url and $returned_unambig_url SHOULD contain the port number (if applicable for the driver) but WILL NOT contain a password
-        is($returned_unambig_url, $orig_unambig_url, 'pipeline initialized on '.$url);
-    }, sprintf('init_pipeline("%s", %s)', $file_or_module, stringify($options)));
+    return _test_ehive_script('init_pipeline', undef, \@args);
 }
 
 

--- a/t/02.api/create_drop_database.t
+++ b/t/02.api/create_drop_database.t
@@ -44,7 +44,7 @@ foreach my $test_url (@$ehive_test_pipeline_urls) {
     if ($dbc->driver eq 'sqlite') {
         run_sql_on_db($test_url, 'DROP DATABASE', "'rm -f' doesn't care about missing files");
     } else {
-        is(system(@{ $dbc->to_cmd(undef, undef, undef, 'DROP DATABASE') }), 256, "Cannot drop a database that doesn't exist");
+        run_sql_on_db($test_url, 'DROP DATABASE', "Can drop a database that exists", {'expect_failure' => 1});
     }
     run_sql_on_db($test_url, 'CREATE DATABASE', 'Can create a database');
     run_sql_on_db($test_url, 'CREATE DATABASE IF NOT EXISTS', 'Further CREATE DATABASE statements are ignored') unless $dbc->driver eq 'pgsql';

--- a/t/02.api/fetch_and_count_by_multiple_columns.t
+++ b/t/02.api/fetch_and_count_by_multiple_columns.t
@@ -37,7 +37,7 @@ my $ehive_test_pipeline_urls = get_test_urls();
 foreach my $pipeline_url (@$ehive_test_pipeline_urls) {
 
 subtest 'Test on '.$pipeline_url, sub {
-    plan tests => 20;
+    plan tests => 17;
 
 init_pipeline('Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMult_conf', $pipeline_url);
 

--- a/t/03.scripts/beekeeper_big_red_button.t
+++ b/t/03.scripts/beekeeper_big_red_button.t
@@ -44,10 +44,9 @@ my $test_filename = 'foo';
 my $pipeline_url = get_test_url_or_die();
 
 {
-    # The init_pipeline test runs in the same process, so @INC needs
-    # to be updated to see the test modules
-    local @INC = @INC;
-    push @INC, $local_module_path;
+    # PERL5LIB needs to be updated in order to see
+    # TestPipeConfig::LongWorker_conf and TestRunnable::DummyWriter
+    local $ENV{'PERL5LIB'} = "$local_module_path:" . $ENV{'PERL5LIB'};
     init_pipeline(
         'TestPipeConfig::LongWorker_conf',
         $pipeline_url,

--- a/t/03.scripts/beekeeper_opts.t
+++ b/t/03.scripts/beekeeper_opts.t
@@ -69,7 +69,7 @@ my $pipeline_url = get_test_url_or_die();
     beekeeper($hive_dba->dbc->url,
         ['-run', -job_id => 98765],
         'beekeeper complained that the job cannot be found',
-        {'expect_failure' => 1},
+        {'expect_failure' => qr/Could not fetch Job with dbID=98765/},
     );
 
     $beekeeper_rows = $beekeeper_nta->fetch_all();
@@ -88,7 +88,7 @@ my $pipeline_url = get_test_url_or_die();
         $hive_dba->dbc->url,
         ['-loop', -analyses_pattern => 'this_matches_no_analysis'],
         'beekeeper complained that no analysis could be matched',
-        {'expect_failure' => 1},
+        {'expect_failure' => qr/the -analyses_pattern 'this_matches_no_analysis' did not match any Analyses/},
     );
 
     $beekeeper_rows = $beekeeper_nta->fetch_all();

--- a/t/03.scripts/beekeeper_opts.t
+++ b/t/03.scripts/beekeeper_opts.t
@@ -34,8 +34,8 @@ my $pipeline_url = get_test_url_or_die();
     # Starting a first set of checks with a "GCPct" pipeline
 
     {
-        local @INC = @INC;
-        push @INC, $ENV{'EHIVE_ROOT_DIR'}.'/t/03.scripts/';
+        # PERL5LIB needs to be updated in order to see TestPipeConfig::LongWorker_conf
+        local $ENV{'PERL5LIB'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/03.scripts/' . ':' . $ENV{'PERL5LIB'};
         init_pipeline('TestPipeConfig::LongWorker_conf', $pipeline_url);
     }
 

--- a/t/03.scripts/generate_graph.t
+++ b/t/03.scripts/generate_graph.t
@@ -39,10 +39,14 @@ GetOptions(
 
 my $server_url  = get_test_url_or_die(-tag => 'server', -no_user_prefix => 1);
 
-# Most of the test scripts test init_pipeline() from Utils::Test but we
-# also need to test the main scripts/init_pipeline.pl !
-my @init_pipeline_args = ($ENV{'EHIVE_ROOT_DIR'}.'/scripts/init_pipeline.pl', 'Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMultServer_conf', -pipeline_url => $server_url, -hive_force_init => 1, -tweak => 'pipeline.param[take_time]=0');
-test_command(\@init_pipeline_args);
+init_pipeline(
+    'Bio::EnsEMBL::Hive::Examples::LongMult::PipeConfig::LongMultServer_conf',
+    $server_url,
+    [],
+    [
+        'pipeline.param[take_time]=0',
+    ],
+);
 
 
 my $client_url  = get_test_url_or_die(-tag => 'client', -no_user_prefix => 1);
@@ -58,12 +62,6 @@ push @confs_to_test, 'GC::PipeConfig::GCPct_conf' unless $@;    # SKIP it in cas
 # A temporary file to store the output of generate_graph.pl
 my ($fh, $tmp_filename) = tempfile(UNLINK => 1);
 close($fh);
-
-sub test_command {
-    my $cmd_array = shift;
-    ok(!system(@$cmd_array), 'Can run '.join(' ', @$cmd_array));
-}
-
 
 foreach my $conf (@confs_to_test) {
   subtest $conf, sub {

--- a/t/10.pipeconfig/analysis_heir.t
+++ b/t/10.pipeconfig/analysis_heir.t
@@ -64,9 +64,13 @@ subtest 'Drop on error' => sub {
     );
 
     my $dbc = Bio::EnsEMBL::Hive::DBSQL::DBConnection->new(-url => $pipeline_url);
-    throws_ok {
-        $dbc->connect;
-    } qr/Could not connect to database.*DBI connect\(.*\) failed/s, q{The database doesn't exist};
+    if ($dbc->driver eq 'sqlite') {
+        ok(!-e $dbc->dbname, $dbc->dbname . q{ doesn't exist})
+    } else {
+        throws_ok {
+            $dbc->connect;
+        } qr/Could not connect to database.*DBI connect\(.*\) failed/s, q{The database doesn't exist};
+    }
 
 };
 

--- a/t/10.pipeconfig/analysis_heir.t
+++ b/t/10.pipeconfig/analysis_heir.t
@@ -32,8 +32,7 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 my $pipeline_url = get_test_url_or_die();
 
 my $init_stderr = capture_stderr {
-    local @INC = @INC;
-    push @INC, $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/';
+    local $ENV{'PERL5LIB'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/::'.$ENV{PERL5LIB};
     init_pipeline(
         'TestPipeConfig::MissingAnalysis_conf',
         $pipeline_url,

--- a/t/10.pipeconfig/gc_dataflow.t
+++ b/t/10.pipeconfig/gc_dataflow.t
@@ -30,8 +30,7 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 my $pipeline_url  = get_test_url_or_die();
 
 {
-    local @INC = @INC;
-    push @INC, $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/';
+    local $ENV{'PERL5LIB'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/::'.$ENV{PERL5LIB};
     init_pipeline('TestPipeConfig::AnyFailureBranch_conf', $pipeline_url, [], ['pipeline.param[take_time]=100']);
 }
 my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );

--- a/t/10.pipeconfig/pipeline_url.t
+++ b/t/10.pipeconfig/pipeline_url.t
@@ -21,7 +21,7 @@ use warnings;
 
 use Test::More;
 
-use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline beekeeper get_test_url_or_die safe_drop_database);
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline get_test_url_or_die safe_drop_database);
 use Bio::EnsEMBL::Hive::Utils qw(destringify);
 
 # eHive needs this to initialize the pipeline (and run db_cmd.pl)
@@ -29,11 +29,10 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 
 my $pipeline_url  = get_test_url_or_die();
 
-# Utils::Test::init_pipeline runs things internally instead of invoking init_pipeline.pl
-# Here we need to run the script to trigger the password sanitization
-my @cmd = ('env', 'PERL5LIB='.$ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/::'.$ENV{PERL5LIB}, $ENV{'EHIVE_ROOT_DIR'}.'/scripts/init_pipeline.pl', 'TestPipeConfig::PipelineURL_conf', -pipeline_url => $pipeline_url);
-my $rc = system(@cmd);
-is($rc, 0, 'init_pipeline.pl successfully ran');
+{
+    local $ENV{'PERL5LIB'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/::'.$ENV{PERL5LIB};
+    init_pipeline('TestPipeConfig::PipelineURL_conf', $pipeline_url);
+}
 
 my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
 


### PR DESCRIPTION
## Use case

1. `init_pipeline` was the last script tested in the test process itself. A long time ago, I thought it would simplify testing, but I gradually realised it's causing more problems because it is not isolated from the test process. All test functions have since been moved to calling the script with `system` and `init_pipeline` was the last one to work the old way.
One problem is that it loads all the Runnables and registers the pipeline in TheApiary. And since the main script was not tested, some tests were explicitly not using the test function in order to test the script.

2. The other thing I'm addressing here is the ability to expect script failures and to test the error message.

3. If there is say a syntax error in a Runnable, `init_pipeline.pl` rightly detects it:
    ```
    $ init_pipeline.pl Bio::EnsEMBL::Compara::PipeConfig::DumpMultiAlign_conf $(mysql-ens-compara-prod-5-ensadmin details hive) -compara_db $(mysql-ens-compara-prod-9-ensadmin details url muffato_salmonids_epo_101) -division vertebrates -mlss_id 1894 -split_by_chromosome 0 -rel_suffix b
    > Parsing the command-line options.
    > Running the creation commands.
    > Parsing the PipeConfig file and adding objects (this may take a while).
    The runnable module 'Bio::EnsEMBL::Compara::RunnableDB::DumpMultiAlign::MLSSJobFactory' cannot be loaded or compiled:
    Global symbol "$mlss_id" requires explicit package name (did you forget to declare "my $mlss_id"?) at /homes/muffato/workspace/src/rel101/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm line 98.
    Global symbol "$mlss_id" requires explicit package name (did you forget to declare "my $mlss_id"?) at /homes/muffato/workspace/src/rel101/ensembl-compara/modules/Bio/EnsEMBL/Compara/RunnableDB/DumpMultiAlign/MLSSJobFactory.pm line 104.
    Compilation failed in require at (eval 41) line 2.
    ```
    However, this leaves the database in a partial state and I need to add `-hive_force_init 1` once I have fixed the Runnable.

## Description

1/2. I have reimplemented the test `init_pipeline` function to use `_test_ehive_script`, which now has an extra parameter named `$flags` with test options. At this time the only option is `expect_failure` which is either 1 or the regular expression to match the script's standard error against.
3. I made `init_pipeline.pl` drop the database if the initialisation is not complete, which makes it quicker for the user.

## Possible Drawbacks

Perhaps some users manipulate TheApiary in tests after calling `init_pipeline`. They would have to add a line of code to load the pipeline from the database.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes