### PR TITLE
Cleaner Python code

### DIFF
--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -32,7 +32,7 @@ else
 fi
 rt=$?
 
-(cd wrappers/python3; python3 -m unittest -v eHive.Process)
+(cd wrappers/python3; python3 -m unittest -v eHive.process)
 rtp=$?
 (cd wrappers/java; mvn "-Dmaven.repo.local=$HOME/deps/maven" test)
 rtj=$?

--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -32,7 +32,7 @@ else
 fi
 rt=$?
 
-(cd wrappers/python3; python3 -m unittest -v eHive.process)
+(cd wrappers/python3; python3 -m unittest -v eHive.process eHive.params)
 rtp=$?
 (cd wrappers/java; mvn "-Dmaven.repo.local=$HOME/deps/maven" test)
 rtj=$?

--- a/wrappers/python3/README.md
+++ b/wrappers/python3/README.md
@@ -10,6 +10,6 @@ of the same name. The class must inherit from eHive.BaseRunnable (see
 eHive.examples.LongMult.DigitFactory for an example) and implement the
 usual `fetch_input()`, `run()`, and / or `write_output()` methods.
 
-Runnables can use the eHive API (like `param()`). See eHive.process.BaseRunnable
+Runnables can use the eHive API (like `param()`). See eHive.BaseRunnable
 for the list of available methods.
 

--- a/wrappers/python3/README.md
+++ b/wrappers/python3/README.md
@@ -10,6 +10,6 @@ of the same name. The class must inherit from eHive.BaseRunnable (see
 eHive.examples.LongMult.DigitFactory for an example) and implement the
 usual `fetch_input()`, `run()`, and / or `write_output()` methods.
 
-Runnables can use the eHive API (like `param()`). See eHive.Process.BaseRunnable
+Runnables can use the eHive API (like `param()`). See eHive.process.BaseRunnable
 for the list of available methods.
 

--- a/wrappers/python3/eHive/__init__.py
+++ b/wrappers/python3/eHive/__init__.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # We take all the interesting classes from both modules, i.e. BaseRunnable and all the exceptions
-from .Process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
-from .Params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning
+from .process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
+from .params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning
 
 __all__ = ['BaseRunnable', 'CompleteEarlyException', 'JobFailedException', 'ParamException', 'ParamNameException', 'ParamSubstitutionException', 'ParamInfiniteLoopException', 'ParamWarning', '__version__']
 

--- a/wrappers/python3/eHive/__init__.py
+++ b/wrappers/python3/eHive/__init__.py
@@ -14,6 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Reference python3 implementation of eHive's "GuestLanguage" protocol.
+
+It allows to write Runnables in python3 and add them to standard eHive
+pipelines, potentially alongside Perl Runnables.
+
+Like in Perl, analyses are given a module name, which must contain a class
+of the same name. The class must inherit from eHive.BaseRunnable (see
+eHive.examples.LongMult.DigitFactory for an example) and implement the
+usual `fetch_input()`, `run()`, and / or `write_output()` methods.
+
+Runnables can use the eHive API (like `param()`). See eHive.BaseRunnable
+for the list of available methods.
+"""
+
 # We take all the interesting classes from both modules, i.e. BaseRunnable and all the exceptions
 from .process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
 from .params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning

--- a/wrappers/python3/eHive/__init__.py
+++ b/wrappers/python3/eHive/__init__.py
@@ -33,5 +33,8 @@ for the list of available methods.
 from .process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
 from .params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning
 
-__all__ = ['BaseRunnable', 'CompleteEarlyException', 'JobFailedException', 'ParamException', 'ParamNameException', 'ParamSubstitutionException', 'ParamInfiniteLoopException', 'ParamWarning', '__version__']
-
+__all__ = [
+    'BaseRunnable', 'CompleteEarlyException', 'JobFailedException',
+    'ParamException', 'ParamNameException', 'ParamSubstitutionException', 'ParamInfiniteLoopException', 'ParamWarning',
+    '__version__',
+]

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -22,7 +22,6 @@ All the specific warnings and exceptions inherit from ParamWarning
 and ParamException.
 """
 
-import sys
 import numbers
 import collections
 

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -22,8 +22,8 @@ All the specific warnings and exceptions inherit from ParamWarning
 and ParamException.
 """
 
-import numbers
 import collections
+import numbers
 
 
 class ParamWarning(Warning):

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -67,15 +67,13 @@ class ParamContainer:
 
     def set_param(self, param_name, value):
         """Setter. Returns the new value"""
-        if not self.validate_parameter_name(param_name):
-            raise ParamNameException(param_name)
+        self.validate_parameter_name(param_name)
         self.param_hash[param_name] = value
         return value
 
     def get_param(self, param_name):
         """Getter. Performs the parameter substitution"""
-        if not self.validate_parameter_name(param_name):
-            raise ParamNameException(param_name)
+        self.validate_parameter_name(param_name)
         self.substitution_in_progress = collections.OrderedDict()
         try:
             return self.internal_get_param(param_name)
@@ -85,8 +83,7 @@ class ParamContainer:
 
     def has_param(self, param_name):
         """Returns a boolean. It checks both substituted and unsubstituted parameters"""
-        if not self.validate_parameter_name(param_name):
-            raise ParamNameException(param_name)
+        self.validate_parameter_name(param_name)
         return (param_name in self.param_hash) or (param_name in self.unsubstituted_param_hash)
 
 
@@ -94,7 +91,8 @@ class ParamContainer:
     ##################
     def validate_parameter_name(self, param_name):
         """Tells whether "param_name" is a non-empty string"""
-        return isinstance(param_name, str) and (param_name != '')
+        if not isinstance(param_name, str) or (param_name == ''):
+            raise ParamNameException(param_name)
 
     def debug_print(self, *args, **kwargs):
         """Print debug information if the debug flag is turned on (cf constructor)"""

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -209,7 +209,7 @@ class ParamContainer:
 
         # We ask the caller to provide the is_expr tag to avoid checking the string again for the presence of the "expr" tokens
         if is_expr:
-            s = self.subst_all_hashpairs(inside_hashes[5:-5].strip(), lambda middle_param: 'self.internal_get_param("{0}")'.format(middle_param))
+            s = self.subst_all_hashpairs(inside_hashes[5:-5].strip(), 'self.internal_get_param("{0}")'.format)
             val = eval(s)
 
         elif ':' in inside_hashes:

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -258,6 +258,7 @@ class ParamContainerTestSubstitutions(unittest.TestCase):
         TestParamEntry('alpha', 2, 2),
         TestParamEntry('beta', 5, 5),
         TestParamEntry('delta', '#expr( #alpha#*#beta# )expr#', 10),
+        TestParamEntry('epsilon', 'alpha#beta', 'alpha#beta'),  # Single hash -> no substitution
 
         TestParamEntry('gamma', [10, 20, 33, 15], [10, 20, 33, 15]),
         TestParamEntry('gamma_prime', '#expr( #gamma# )expr#', [10, 20, 33, 15]),

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -53,7 +53,7 @@ class NullParamException(ParamException):
         return "{0} is None".format(self.args[0])
 
 
-class ParamContainer(object):
+class ParamContainer:
     """Equivalent of eHive's Param module"""
 
     def __init__(self, unsubstituted_params, debug=False):

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -28,7 +28,7 @@ and ParamException.
 
 
 class ParamWarning(Warning):
-    """Used by Process.BaseRunnable"""
+    """Used by process.BaseRunnable"""
     pass
 
 

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -86,6 +86,14 @@ class ParamContainer:
         self.validate_parameter_name(param_name)
         return (param_name in self.param_hash) or (param_name in self.unsubstituted_param_hash)
 
+    def substitute_string(self, string):
+        """Apply the parameter substitution to the string"""
+        self.substitution_in_progress = collections.OrderedDict()
+        try:
+            return self.param_substitute(string)
+        except (KeyError, SyntaxError, ParamException) as e:
+            # To hide the part of the stack that is in ParamContainer
+            raise e.with_traceback(None)
 
     # Private methods
     ##################

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -14,17 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import numbers
-import collections
-
-__doc__ = """
+"""
 This module is an implementation of eHive's Param module.
 It defines ParamContainer which is an attribute of BaseRunnable
 and not its base class as in eHive's class hierarchy.
 All the specific warnings and exceptions inherit from ParamWarning
 and ParamException.
 """
+
+import sys
+import numbers
+import collections
 
 
 class ParamWarning(Warning):

--- a/wrappers/python3/eHive/params.py
+++ b/wrappers/python3/eHive/params.py
@@ -79,7 +79,7 @@ class ParamContainer:
             return self.internal_get_param(param_name)
         except (KeyError, SyntaxError, ParamException) as e:
             # To hide the part of the stack that is in ParamContainer
-            raise type(e)(*e.args) from None
+            raise e.with_traceback(None)
 
     def has_param(self, param_name):
         """Returns a boolean. It checks both substituted and unsubstituted parameters"""

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -86,7 +86,7 @@ class BaseRunnable:
         # UTF8 encoding has never been tested. Just hope it works :)
         try:
             self.__write_pipe.write(bytes(j+"\n", 'utf-8'))
-        except BrokenPipeError as e:
+        except BrokenPipeError:
             raise LostHiveConnectionException("__write_pipe") from None
 
     def __send_response(self, response):
@@ -95,7 +95,7 @@ class BaseRunnable:
         # Like above, UTF8 encoding has never been tested. Just hope it works :)
         try:
             self.__write_pipe.write(bytes('{"response": "' + str(response) + '"}\n', 'utf-8'))
-        except BrokenPipeError as e:
+        except BrokenPipeError:
             raise LostHiveConnectionException("__write_pipe") from None
 
     def __read_message(self):
@@ -105,7 +105,7 @@ class BaseRunnable:
             l = self.__read_pipe.readline()
             self.__print_debug(" ... -> ", l[:-1].decode())
             return json.loads(l.decode())
-        except BrokenPipeError as e:
+        except BrokenPipeError:
             raise LostHiveConnectionException("__read_pipe") from None
         except ValueError as e:
             # HiveJSONMessageException is a more meaningful name than ValueError

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -284,7 +284,7 @@ class BaseRunnable:
         except KeyError:
             return False
 
-class RunnableTest(unittest.TestCase):
+class BaseRunnableTestCase(unittest.TestCase):
     def test_job_param(self):
         class FakeRunnableWithParams(BaseRunnable):
             def __init__(self, d):

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -22,7 +22,7 @@ import unittest
 import warnings
 import traceback
 
-from . import Params
+from . import params
 
 __version__ = "5.0"
 
@@ -135,8 +135,8 @@ class BaseRunnable(object):
         """Job's life-cycle. See GuestProcess for a description of the protocol to communicate with the parent"""
         self.__print_debug("__life_cycle")
 
-        # Params
-        self.__params = Params.ParamContainer(config['input_job']['parameters'], self.debug > 1)
+        # Parameters
+        self.__params = params.ParamContainer(config['input_job']['parameters'], self.debug > 1)
 
         # Job attributes
         self.input_job = Job()
@@ -240,7 +240,7 @@ class BaseRunnable(object):
         self.input_job.transient_error = False
         v = self.__params.get_param(param_name)
         if v is None:
-            raise Params.NullParamException(param_name)
+            raise params.NullParamException(param_name)
         self.input_job.transient_error = t
         return v
 
@@ -257,7 +257,7 @@ class BaseRunnable(object):
         try:
             return self.__params.get_param(param_name)
         except KeyError as e:
-            warnings.warn("parameter '{0}' cannot be initialized because {1} is missing !".format(param_name, e), Params.ParamWarning, 2)
+            warnings.warn("parameter '{0}' cannot be initialized because {1} is missing !".format(param_name, e), params.ParamWarning, 2)
             return None
 
     def param_exists(self, param_name):
@@ -288,7 +288,7 @@ class RunnableTest(unittest.TestCase):
     def test_job_param(self):
         class FakeRunnableWithParams(BaseRunnable):
             def __init__(self, d):
-                self._BaseRunnable__params = Params.ParamContainer(d)
+                self._BaseRunnable__params = params.ParamContainer(d)
                 self.input_job = Job()
                 self.input_job.transient_error = True
         j = FakeRunnableWithParams({
@@ -303,7 +303,7 @@ class RunnableTest(unittest.TestCase):
         self.assertIs( j.param_exists('b'), True, '"b" exists' )
         self.assertIs( j.param_exists('c'), None, '"c"\'s existence is unclear' )
         self.assertIs( j.param_exists('d'), False, '"d" doesn\'t exist' )
-        with self.assertRaises(Params.ParamInfiniteLoopException):
+        with self.assertRaises(params.ParamInfiniteLoopException):
             j.param_exists('e')
 
         # param_is_defined
@@ -311,27 +311,27 @@ class RunnableTest(unittest.TestCase):
         self.assertIs( j.param_is_defined('b'), False, '"b" is not defined' )
         self.assertIs( j.param_is_defined('c'), None, '"c"\'s defined-ness is unclear' )
         self.assertIs( j.param_is_defined('d'), False, '"d" is not defined (it doesn\'t exist)' )
-        with self.assertRaises(Params.ParamInfiniteLoopException):
+        with self.assertRaises(params.ParamInfiniteLoopException):
             j.param_is_defined('e')
 
         # param
         self.assertIs( j.param('a'), 3, '"a" is 3' )
         self.assertIs( j.param('b'), None, '"b" is None' )
-        with self.assertWarns(Params.ParamWarning):
+        with self.assertWarns(params.ParamWarning):
             self.assertIs( j.param('c'), None, '"c"\'s value is unclear' )
-        with self.assertWarns(Params.ParamWarning):
+        with self.assertWarns(params.ParamWarning):
             self.assertIs( j.param('d'), None, '"d" is not defined (it doesn\'t exist)' )
-        with self.assertRaises(Params.ParamInfiniteLoopException):
+        with self.assertRaises(params.ParamInfiniteLoopException):
             j.param('e')
 
         # param_required
         self.assertIs( j.param_required('a'), 3, '"a" is 3' )
-        with self.assertRaises(Params.NullParamException):
+        with self.assertRaises(params.NullParamException):
             j.param_required('b')
         with self.assertRaises(KeyError):
             j.param_required('c')
         with self.assertRaises(KeyError):
             j.param_required('d')
-        with self.assertRaises(Params.ParamInfiniteLoopException):
+        with self.assertRaises(params.ParamInfiniteLoopException):
             j.param_required('e')
 

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -22,7 +22,6 @@ the later for more information about the JSON protocol used to communicate.
 import os
 import sys
 import json
-import numbers
 import unittest
 import warnings
 import traceback

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -169,18 +169,18 @@ class BaseRunnable:
         except LostHiveConnectionException as e:
             # Mothing we can do, let's just exit
             raise
-        except:
+        except Exception as e:
             died_somewhere = True
-            self.warning( self.__traceback(2), True)
+            self.warning( self.__traceback(e, 2), True)
 
         try:
             self.__run_method_if_exists('post_cleanup')
         except LostHiveConnectionException as e:
             # Mothing we can do, let's just exit
             raise
-        except:
+        except Exception as e:
             died_somewhere = True
-            self.warning( self.__traceback(2), True)
+            self.warning( self.__traceback(e, 2), True)
 
         job_end_structure = {'complete' : not died_somewhere, 'job': {}, 'params': {'substituted': self.__params.param_hash, 'unsubstituted': self.__params.unsubstituted_param_hash}}
         for x in [ 'autoflow', 'lethal_for_worker', 'transient_error' ]:
@@ -194,11 +194,10 @@ class BaseRunnable:
             self.__send_message_and_wait_for_OK('JOB_STATUS_UPDATE', method)
             getattr(self, method)()
 
-    def __traceback(self, skipped_traces):
+    def __traceback(self, exception, skipped_traces):
         """Remove "skipped_traces" lines from the stack trace (the eHive part)"""
-        (etype, value, tb) = sys.exc_info()
-        s1 = traceback.format_exception_only(etype, value)
-        l = traceback.extract_tb(tb)[skipped_traces:]
+        s1 = traceback.format_exception_only(type(exception), exception)
+        l = traceback.extract_tb(exception.__traceback__)[skipped_traces:]
         s2 = traceback.format_list(l)
         return "".join(s1+s2)
 

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -31,7 +31,7 @@ This module mainly implements python's counterpart of GuestProcess. Read
 the later for more information about the JSON protocol used to communicate.
 """
 
-class Job(object):
+class Job:
     """Dummy class to hold job-related information"""
     pass
 
@@ -49,7 +49,7 @@ class LostHiveConnectionException(Exception):
     pass
 
 
-class BaseRunnable(object):
+class BaseRunnable:
     """This is the counterpart of GuestProcess. Note that most of the methods
     are private to be hidden in the derived classes.
 

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -19,12 +19,12 @@ This module mainly implements python's counterpart of GuestProcess. Read
 the later for more information about the JSON protocol used to communicate.
 """
 
+import json
 import os
 import sys
-import json
+import traceback
 import unittest
 import warnings
-import traceback
 
 from . import params
 

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+This module mainly implements python's counterpart of GuestProcess. Read
+the later for more information about the JSON protocol used to communicate.
+"""
+
 import os
 import sys
 import json
@@ -26,10 +31,6 @@ from . import params
 
 __version__ = "5.0"
 
-__doc__ = """
-This module mainly implements python's counterpart of GuestProcess. Read
-the later for more information about the JSON protocol used to communicate.
-"""
 
 class Job:
     """Dummy class to hold job-related information"""


### PR DESCRIPTION
## Use case

As Ensembl is doing more Python there will be more scrutiny on eHive's Python wrapper. `pylint` is a popular Python linter. It complains quite a lot about our code :see_no_evil: as we are not following Python's best practices

## Description

I'm not (yet) keen on addressing every complain, especially as it would change the file history and make it more difficult to trace back the origin of the implementation. However, I think that some changes should still be made in order not to be too far away from the Python world.

I have applied these changes:
- the eHive internal modules are all named in lower case. I haven't changed the main package name `eHive` and the example runnables because that would be a breaking change.
- All internal modules have a dosctring at the beginning
- I broke down the `__all__` line of `__init__.py` to make it easier to maintain (see the next PR #167)
- I have cleaned and ordered the import statements
- I have turned the tests of the Params class into an actual TestCase that is run on Travis
- I have removed `(object)` from the class definition because it's not needed in Python 3
- Slight refactoring of the handling of _tracebacks_ and `validate_parameter_name`

Here are some pylint tests that I have not applied:
- trailing-whitespace
- line-too-long
- bad-whitespace
- trailing-newlines
- unnecessary-pass
- no-else-return
- eval-used

Note that this branch currently includes two commits from #160. I'll remove them once the PR is integrated

## Possible Drawbacks

The functionality is the same.
The per-line history will have changed, but I have tried not to change it too much

## Testing

_Have you added/modified unit tests to test the changes?_

Yes

_If so, do the tests pass/fail?_

Yes

_Have you run the entire test suite and no regression was detected?_

Yes