### PR TITLE
bugfix: the version of sqlite3 for Ubuntu 18.04 is 1.56, not 1.58

### DIFF
--- a/docs/rtd_upgrade.sh
+++ b/docs/rtd_upgrade.sh
@@ -31,7 +31,7 @@ mkdir packages
 cd packages
 # List of extra packages we need
 echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.640-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.58-1_amd64.deb \
+     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.56-1_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libj/libjson-xs-perl/libjson-xs-perl_3.040-1_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/main/libj/libjson-perl/libjson-perl_2.90-1_all.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libc/libcommon-sense-perl/libcommon-sense-perl_3.74-2build2_amd64.deb \


### PR DESCRIPTION
## Use case

I've found out that the readthedocs are failing (on both 2.5 and master) because this sqlite .deb file can't be found

## Description

According to https://packages.ubuntu.com/bionic/libdbd-sqlite3-perl, the current version on Ubuntu 18.04 (the one used on readthedocs) is 1.56, not 1.58

## Possible Drawbacks

None

## Testing

ReadTheDocs built successfully: https://readthedocs.org/projects/ensembl-hive/builds/11385254/
