### PR TITLE
Use `apt` to download the packages

### DIFF
--- a/docs/rtd_upgrade.sh
+++ b/docs/rtd_upgrade.sh
@@ -31,7 +31,7 @@ mkdir packages
 cd packages
 # List of extra packages we need
 echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.640-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.58-1_amd64.deb \
+     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.56-1_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libj/libjson-xs-perl/libjson-xs-perl_3.040-1_amd64.deb \
      http://archive.ubuntu.com/ubuntu/pool/main/libj/libjson-perl/libjson-perl_2.90-1_all.deb \
      http://archive.ubuntu.com/ubuntu/pool/universe/libc/libcommon-sense-perl/libcommon-sense-perl_3.74-2build2_amd64.deb \

--- a/docs/rtd_upgrade.sh
+++ b/docs/rtd_upgrade.sh
@@ -30,20 +30,21 @@ perl --version
 mkdir packages
 cd packages
 # List of extra packages we need
-echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.640-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libd/libdbd-sqlite3-perl/libdbd-sqlite3-perl_1.56-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libj/libjson-xs-perl/libjson-xs-perl_3.040-1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libj/libjson-perl/libjson-perl_2.90-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libc/libcommon-sense-perl/libcommon-sense-perl_3.74-2build2_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libt/libtypes-serialiser-perl/libtypes-serialiser-perl_1.0-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libx/libxml-xpath-perl/libxml-xpath-perl_1.30-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libp/libparse-recdescent-perl/libparse-recdescent-perl_1.967013+dfsg-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libi/libipc-run-perl/libipc-run-perl_0.94-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/main/libi/libio-pty-perl/libio-pty-perl_1.08-1.1build1_amd64.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgraphviz-perl/libgraphviz-perl_2.20-1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/d/doxypy/doxypy_0.4.2-1.1_all.deb \
-     http://archive.ubuntu.com/ubuntu/pool/universe/libp/libproc-daemon-perl/libproc-daemon-perl_0.23-1_all.deb \
-| xargs -n 1 curl -O
+apt-get download \
+     libdbi-perl \
+     libdbd-sqlite3-perl \
+     libjson-xs-perl \
+     libjson-perl \
+     libcommon-sense-perl \
+     libtypes-serialiser-perl \
+     libxml-xpath-perl \
+     libparse-recdescent-perl \
+     libipc-run-perl \
+     libio-pty-perl \
+     libgraphviz-perl \
+     doxypy \
+     libproc-daemon-perl \
+
 
 mkdir ../root
 for i in *.deb; do dpkg -x "$i" ../root/; done


### PR DESCRIPTION
Supersedes #168 

## Use case

We currently get the .deb packages by directly downloading them from the Ubuntu repository. This involves finding the version and the actual path via https://packages.ubuntu.com and maintaining the list. We've had to update the URLs several times as the ReadTheDocs builds were broken.

## Description

Here I suggest using `apt-get download` to download the packages. It will itself select the right version and download it from the Ubuntu repository.

## Possible Drawbacks

`apt-get` requires the `apt` cache to be populated (typically `apt-cache update`) but we can't do that as non-root, so we need to hope it's been done, which seems to be the case :)

## Testing

ReadTheDocs built successfully: https://readthedocs.org/projects/ensembl-hive/builds/11386178/
