### PR TITLE
Don't use the enhanced mode as it messes up most analysis names

### DIFF
--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -105,13 +105,13 @@ sub main {
     my @palette = qw(#E41A1C #377EB8 #4DAF4A #984EA3 #FF7F00 #FFFF33 #A65628 #F781BF #999999     #8DD3C7 #BEBADA #FB8072 #80B1D3 #FDB462 #B3DE69 #FCCDE5 #D9D9D9 #BC80BD #CCEBC5 #FFED6F    #2F4F4F);
 
     my %terminal_mapping = (
-        'emf' => 'emf',
-        'png' => 'png',
-        'svg' => 'svg',
-        'jpg' => 'jpeg',
-        'gif' => 'gif',
-        'ps'  => 'postscript eps enhanced color',
-        'pdf' => 'pdf color enhanced',
+        'emf' => 'emf noenhanced',
+        'png' => 'png noenhanced',
+        'svg' => 'svg noenhanced',
+        'jpg' => 'jpeg noenhanced',
+        'gif' => 'gif noenhanced',
+        'ps'  => 'postscript eps noenhanced color',
+        'pdf' => 'pdf color noenhanced',
     );
     my $gnuplot_terminal = undef;
     if ($output and $output =~ /\.(\w+)$/) {


### PR DESCRIPTION
## Use case

In Gnuplot's enhanced mode (which powers `generate_timeline.pl`), the string "a_b" is displayed as "a" followed by "b" in subscript. Most of our analyses use underscore, so the names are quite messed up.

## Description

The fix is simply to disable the enhanced mode.

## Possible Drawbacks

Note

## Merging tips

For `ps` and `pdf` formats, the instruction "color" has been renamed to "colour" in a later version of eHive. That will conflict when you do the merge.

## Testing

_Have you added/modified unit tests to test the changes?_

There is no unit-test for generate_timeline, but here is how the changes look:
![subscript](https://user-images.githubusercontent.com/623458/87063320-1bc97000-c206-11ea-9949-a574e13688a6.png)
![normal](https://user-images.githubusercontent.com/623458/87063316-1b30d980-c206-11ea-8555-d5ebb2bc5c7b.png)

(the diagrams were generated on different databases, hence the different ordering of the analyses)
