### PR TITLE
One hash fix

### DIFF
--- a/wrappers/python3/eHive/Params.py
+++ b/wrappers/python3/eHive/Params.py
@@ -160,7 +160,7 @@ class ParamContainer(object):
         """
         self.debug_print("subst_all_hashpairs", structure)
         
-        # Allow a single literal hash?
+        # Allow a single literal hash
         if structure.count("#") == 1:
             return structure
         

--- a/wrappers/python3/eHive/Params.py
+++ b/wrappers/python3/eHive/Params.py
@@ -159,6 +159,11 @@ class ParamContainer(object):
         The result is a string (like structure)
         """
         self.debug_print("subst_all_hashpairs", structure)
+        
+        # Allow a single literal hash?
+        if structure.count("#") == 1:
+            return structure
+        
         result = []
         while True:
             (head,_,tmp) = structure.partition('#')

--- a/wrappers/python3/eHive/examples/TestRunnable.py
+++ b/wrappers/python3/eHive/examples/TestRunnable.py
@@ -22,13 +22,17 @@ class TestRunnable(eHive.BaseRunnable):
     def param_defaults(self):
         return {
             'alpha' : 37,
-            'beta' : 78
+            'beta' : 78,
+            'gamma' : '#alpha#',
+            'delta' : 'one#hash',
         }
 
     def fetch_input(self):
         self.warning("Fetch the world !")
         print("alpha is", self.param_required('alpha'))
         print("beta is", self.param_required('beta'))
+        print("gamma is", self.param_required('gamma'))
+        print("delta is", self.param_required('delta'))
 
     def run(self):
         self.warning("Run the world !")


### PR DESCRIPTION
## Use case

When a parameter contains a string with a single literal "#" symbol in it, the python3 wrapper tries to find a second "#" to do a substitution, and then dies because it cannot find one. This can be the case for e.g. a strain name that contains a "#".

## Description

This simple workaround allows a single "#" symbol to be used within a string as a parameter value when using python runnables.

It doesn't solve the issue in case several literal "#" symbols are in the same string, and it still doesn't allow having substitutions + literal "#". A more general escape mechanism for this special character would be needed, or the behaviour should be documented.

## Possible Drawbacks

The runnables do not fail any more if a placeholder to be substituted only has one "#" instead of two.

## Testing

I've added a substitution test in the TestRunnable.py, with a string parameter with one hash.

I have also run several pipelines with this fix and it solved this rare issue without impacting the normal substitutions.