### PR TITLE
Bugfix LSF detection

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -54,12 +54,16 @@ our $VERSION = '3.1';       # Semantic version of the Meadow interface:
 =cut
 
 sub name {
-    my $mcni = 'My cluster name is';
+    my $re_lsf_names = qr/(IBM Spectrum LSF|Platform LSF|openlava project)/;
+    my $re_cluster_name = qr/^My cluster name is\s+(\S+)/;
     my @lsid_out = `lsid 2>/dev/null`;
 
+    my $is_lsf = 0;
     foreach my $lsid_line (@lsid_out) {
-        if ($lsid_line =~ /^$mcni\s+(\S+)/) {
-            return $1;
+        if ($lsid_line =~ $re_lsf_names) {
+            $is_lsf = 1;
+        } elsif ($lsid_line =~ $re_cluster_name) {
+            return $1 if $is_lsf;
         }
     }
 }

--- a/t/04.meadow/fake_bin/lsid
+++ b/t/04.meadow/fake_bin/lsid
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+echo "Platform LSF"
 echo 'My cluster name is test_clUster'
 

--- a/t/04.meadow/lsf.t
+++ b/t/04.meadow/lsf.t
@@ -35,9 +35,12 @@ $ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( Fil
 my @config_files = Bio::EnsEMBL::Hive::Utils::Config->default_config_files();
 my $config = Bio::EnsEMBL::Hive::Utils::Config->new(@config_files);
 
+my $ini_path = $ENV{'PATH'};
+
 # WARNING: the data in this script must be in sync with what the fake
 # binaries output
-$ENV{'PATH'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/04.meadow/fake_bin:'.$ENV{'PATH'};
+{ # begin local $ENV{'PATH'}
+$ENV{'PATH'} = $ENV{'EHIVE_ROOT_DIR'}.'/t/04.meadow/fake_bin:'.$ini_path;
 
 my $test_pipeline_name = 'tracking_homo_sapiens_funcgen_81_38_hive';
 my $test_meadow_name = 'test_clUster';
@@ -217,6 +220,8 @@ lives_and( sub {
     my $h = $lsf_meadow->get_report_entries_for_time_interval('2015-10-11 12:23:45', '2015-12-12 23:56:59', 'kb3');
     is_deeply($h, {}, 'No bacct output when accounting disabled');
 }, 'Suppressed bacct when AccountingDisabled when checking a date range');
+
+} # end local $ENV{'PATH'}
 
 done_testing();
 

--- a/t/04.meadow/lsf_detection/no_slurm_gcloud/lsid
+++ b/t/04.meadow/lsf_detection/no_slurm_gcloud/lsid
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+exec cat <<EOF
+Slurm 20.02.3, Feb 1 2020
+Copyright SchedMD LLC, 2010-2017.
+
+My cluster name is g2
+My master name is g2-controller
+EOF
+

--- a/t/04.meadow/lsf_detection/ok_EBI/lsid
+++ b/t/04.meadow/lsf_detection/ok_EBI/lsid
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# LSF EBI "noah" farm
+exec cat <<EOF
+IBM Spectrum LSF Standard 10.1.0.6, May 25 2018
+Copyright International Business Machines Corp. 1992, 2016.
+US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+My cluster name is EBI
+My master name is ebi-master-001
+EOF
+

--- a/t/04.meadow/lsf_detection/ok_YODA/lsid
+++ b/t/04.meadow/lsf_detection/ok_YODA/lsid
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# LSF EBI "yoda" farm
+exec cat <<EOF
+IBM Spectrum LSF Standard 10.1.0.0, Jul 08 2016
+Copyright International Business Machines Corp. 1992, 2016.
+US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+My cluster name is YODA
+My master name is hh-yoda-02-02.ebi.ac.uk
+EOF
+

--- a/t/04.meadow/lsf_detection/ok_cluster1/lsid
+++ b/t/04.meadow/lsf_detection/ok_cluster1/lsid
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Old LSF version (7.*)
+# http://sunray2.mit.edu/kits/platform-lsf/7.0.6/1/guides/kit_lsf_guide_source/admin/cluster_ops.html
+exec cat <<EOF
+Platform LSF 7 Update 6 May 6 2009
+Copyright 1992-2009 Platform Computing Corporation
+
+My cluster name is cluster1
+My master name is hostA 
+EOF
+

--- a/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
+++ b/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Old LSF version (9.*)
+# https://www.bsc.es/support/LSF/9.1.2/lsf_admin/index.htm?cluster_info_viewing_lsf.html~main
+exec cat <<EOF
+IBM Platform LSF Standard 9.1.2, May 5 2013 
+© Copyright IBM Corporation 1992, 2013. 
+US Governmant Users Restricted Rights - Use, duplication or disclosure restricted
+  by GSA ADP Schedule Contract with IBM Corp.
+My cluster name is lsf91_bw3 
+My master name is delpe04.lsf.ibm.com
+EOF
+

--- a/t/04.meadow/lsf_detection/ok_openlava/lsid
+++ b/t/04.meadow/lsf_detection/ok_openlava/lsid
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# openlava
+# https://jensd.be/404/linux/install-and-use-the-openlava-job-scheduler-and-openlava-web-gui-on-centos
+exec cat <<EOF
+openlava project 2.2, Nov  6 2014
+
+My cluster name is openlava
+My master name is node01
+EOF
+


### PR DESCRIPTION
## Use case

We are testing some pipelines in a Slurm farm that provides `lsid`, and eHive activates the LSF meadow tries to submit jobs with `bsub` etc, which doesn't exist, and fails.
A workaround is to run beekeeper with `--meadow_type SLURM`, but I believe the LSF meadow should be fixed.

## Description

Slurm's `lsid` does print it is a Slurm, it doesn't pretend to be an LSF. The fix is change the parsing of `lsid` to look for the LSF keyword, and openlava too since they are mostly the same.

## Possible Drawbacks

None envisaged.

## Testing

_Have you added/modified unit tests to test the changes?_

Yes, `lsf.t` now tests the meadow detection against a collection of `lsid` outputs

_If so, do the tests pass/fail?_

They do

_Have you run the entire test suite and no regression was detected?_

All good (but remember that we don't have Travis any more !)