### PR TITLE
Code maintenance - RunnableDB::DatabaseDumper

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
@@ -255,8 +255,7 @@ sub fetch_input {
         } else {
             $self->complete_early("Skipping the dump because this database has been restored from the target dump. We don't want to overwrite it");
         }
-    } elsif ($self->param('nb_ehive_tables')) {
-        # OK, we can dump and this is an eHive database.
+    } elsif ($self->param('nb_ehive_tables') and !$self->worker->adaptor) {
         # We add the signature to the dump, so that the
         # job won't rerun on a restored database
         # We're very lucky that gzipped streams can be concatenated and the
@@ -265,7 +264,7 @@ sub fetch_input {
         $extra_sql =~ s/>/>>/;
         $self->param('cmd', "$cmd; $extra_sql");
     } else {
-        # Direct dump on a non-eHive database
+        # No signature to add (non-eHive database or standalone job)
         $self->param('cmd', $cmd);
     }
 }

--- a/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
+++ b/modules/Bio/EnsEMBL/Hive/RunnableDB/DatabaseDumper.pm
@@ -250,12 +250,10 @@ sub fetch_input {
     my $completion_signature = sprintf('dump_%d_restored', defined $self->input_job->dbID ? $self->input_job->dbID : 0);
 
     if ($self->param('skip_dump') or $self->param($completion_signature)) {
-        # A command that always succeeds
-        $self->param('cmd', 'true');
         if ($self->param('skip_dump')) {
-            $self->warning('Skipping the dump because "skip_dump" is defined');
+            $self->complete_early('Skipping the dump because "skip_dump" is defined');
         } else {
-            $self->warning("Skipping the dump because this database has been restored from the target dump. We don't want to overwrite it");
+            $self->complete_early("Skipping the dump because this database has been restored from the target dump. We don't want to overwrite it");
         }
     } elsif ($self->param('nb_ehive_tables')) {
         # OK, we can dump and this is an eHive database.


### PR DESCRIPTION
## Use case

A few changes to improve maintainability of `RunnableDB::DatabaseDumper`

## Description

1. Instead of setting the command to `true` to breeze through `run` and `write_output`, use `$self->complete_early()` (which was introduced after the creation of this Runnable
2. Don't add the "signature" if the Runnable is run in standalone mode,

## Possible Drawbacks

None envisaged

## Testing

_Have you added/modified unit tests to test the changes?_

There are no tests for this Runnable

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
