### PR TITLE
Fix apache2.t and ascii.t failures

### DIFF
--- a/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
+++ b/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
@@ -4,7 +4,7 @@
 # https://www.bsc.es/support/LSF/9.1.2/lsf_admin/index.htm?cluster_info_viewing_lsf.html~main
 exec cat <<EOF
 IBM Platform LSF Standard 9.1.2, May 5 2013 
-© Copyright IBM Corporation 1992, 2013. 
+(c) Copyright IBM Corporation 1992, 2013.
 US Governmant Users Restricted Rights - Use, duplication or disclosure restricted
   by GSA ADP Schedule Contract with IBM Corp.
 My cluster name is lsf91_bw3 

--- a/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
+++ b/t/04.meadow/lsf_detection/ok_lsf91_bw3/lsid
@@ -4,7 +4,7 @@
 # https://www.bsc.es/support/LSF/9.1.2/lsf_admin/index.htm?cluster_info_viewing_lsf.html~main
 exec cat <<EOF
 IBM Platform LSF Standard 9.1.2, May 5 2013 
-(c) Copyright IBM Corporation 1992, 2013.
+© Copyright IBM Corporation 1992, 2013. 
 US Governmant Users Restricted Rights - Use, duplication or disclosure restricted
   by GSA ADP Schedule Contract with IBM Corp.
 My cluster name is lsf91_bw3 

--- a/t/apache2.t
+++ b/t/apache2.t
@@ -90,6 +90,7 @@ foreach my $f (@source_files) {
     next if $f =~ /\/docutils\//;
     next if $f =~ /\/fake_bin\//;
     next if $f =~ /\/deceptive_bin\//;
+    next if $f =~ /\/lsf_detection\//;
     next if $f =~ /\/deps\//;
     # Unlicensed files
     next if $f =~ /\.(png|jpg|pdf|pyc|tgz|txt|dot|rst|fa|fastq|md|json|xml)$/;

--- a/t/ascii.t
+++ b/t/ascii.t
@@ -70,6 +70,10 @@ foreach my $f (@source_files) {
     next if $f =~ /docs\/contrib\/docker-swarm\/tutorial\.rst$/;
     # Binary files
     next if $f =~ /\.(jar|class|png|jpg|pdf|pyc|tgz)$/;
+    # Simulated program output
+    next if $f =~ /lsf_detection\/.*/;
+    next if $f =~ /deceptive_bin\/.*/;
+    next if $f =~ /fake_bin\/.*/;
     # Unicode-art
     next if $f =~ /modules\/Bio\/EnsEMBL\/Hive\/(Analysis|HivePipeline)\.pm$/;
     next if $f =~ /\/generate_graph\/.*::PipeConfig::.*\.txt$/;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

The recent LSF meadow test expansion added a new directory that needs to be excluded from apache2.t's copyright checks. One of the fake lsid commands also included a non-ASCII character, which was causing ascii.t to fail. The non-ascii character is on a line that is ignored in the LSF meadow checks.

## Description

Add the lsf_detection/ directory to apache2.t's exclude list. Remove the non-ASCII character from ok_lsf91_bw3/lsid

## Possible Drawbacks

The output from the fake lsid does not exactly match the actual lsid output from that particular installation of LSF. 

## Testing

_Have you added/modified unit tests to test the changes?_

Yes, part of this PR is a test modification

_If so, do the tests pass/fail?_

pass

_Have you run the entire test suite and no regression was detected?_

yes