### PR TITLE
Drop error on null hash key in accu

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Accumulator.pm
+++ b/modules/Bio/EnsEMBL/Hive/Accumulator.pm
@@ -137,23 +137,23 @@ sub checkEmptyKeys {
   my ( $self, $key_signature, $accu_address ) = @_;
   # we get number of brackets, that are empty for key signature and address
   # and verify that each empty brackets in key_signature is empty in adress
-  my @curvedBrackets = $self->findEmptyBrackets($key_signature, '{', '}');
-  my @curvedBracketsAddress = $self->findEmptyBrackets($accu_address, '{', '}');
-  my %addressBrackets = map { $_ => 1 } @curvedBracketsAddress;
+  my $curvedBrackets = $self->findEmptyBrackets($key_signature, '{', '}');
+  my $curvedBracketsAddress = $self->findEmptyBrackets($accu_address, '{', '}');
+  my %addressBrackets = map { $_ => 1 } @$curvedBracketsAddress;
 
-  foreach my $position ( @curvedBrackets ) {
+  foreach my $position ( @$curvedBrackets ) {
     if (!exists($addressBrackets{$position})) {
-        die "Null hash key in accumulator";
+        die "Null hash key in accumulator, empty curved brackets number " . $position;
     }
   }
 
-  my @squareBrackets = $self->findEmptyBrackets($key_signature, '[', ']');
-  my @squareBracketsAddress = $self->findEmptyBrackets($accu_address, '[', ']');
-  %addressBrackets = map { $_ => 1 } @squareBracketsAddress;
+  my $squareBrackets = $self->findEmptyBrackets($key_signature, '[', ']');
+  my $squareBracketsAddress = $self->findEmptyBrackets($accu_address, '[', ']');
+  %addressBrackets = map { $_ => 1 } @$squareBracketsAddress;
 
-  foreach my $position ( @squareBrackets ) {
+  foreach my $position ( @$squareBrackets ) {
     if (!exists($addressBrackets{$position})) {
-        die "Null hash key in accumulator";
+        die "Null array key in accumulator, empty square brackets number " . $position;
     }
   }
 }
@@ -161,7 +161,7 @@ sub checkEmptyKeys {
 sub findEmptyBrackets {
     my ( $self, $string, $open, $close ) = @_;
 
-    my @result;
+    my $result;
     my $offset = 0;
     my $openIndex = 0;
     my $numberOfBracket = 0;
@@ -177,7 +177,7 @@ sub findEmptyBrackets {
       if ( $openIndex != -1) {
         $numberOfBracket = $numberOfBracket + 1;
         if ($close eq substr($string, $openIndex+1, 1))  {
-          @result[$i] = $numberOfBracket;
+          $result->[$i] = $numberOfBracket;
           $i = $i + 1;
         }
       }
@@ -185,7 +185,7 @@ sub findEmptyBrackets {
 
     };
 
-    return @result;
+    return $result;
 }
 
 sub toString {

--- a/t/10.pipeconfig/TestPipeConfig/Accumulator/NullHashKey_conf.pm
+++ b/t/10.pipeconfig/TestPipeConfig/Accumulator/NullHashKey_conf.pm
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an intentionally broken PipeConfig for testing purposes.
+# It has a flow_into that goes to an analysis that is not defined
+# in the pipeline.
+
+package TestPipeConfig::Accumulator::NullHashKey_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');  # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
+
+
+=head2 pipeline_create_commands
+
+    Description : Implements pipeline_create_commands() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf
+                  that lists the commands that will create and set up the Hive database.
+                  In addition to the standard creation of the database and populating it with Hive tables and procedures it
+                  also creates a pipeline-specific table called 'final_result' to store the results of the computation.
+
+=cut
+
+sub pipeline_create_commands {
+    my ($self) = @_;
+    return [
+        @{$self->SUPER::pipeline_create_commands},  # inheriting database and hive tables' creation
+
+        # create an additional table to store the end result of the computation:
+        $self->db_cmd('CREATE TABLE final_result (inputfile VARCHAR(255) NOT NULL, result DOUBLE PRECISION NOT NULL, PRIMARY KEY (inputfile))'),
+    ];
+}
+
+
+=head2 pipeline_wide_parameters
+
+    Description : Interface method that should return a hash of
+                  pipeline_wide_parameter_name->pipeline_wide_parameter_value pairs.
+                  The value doesn't have to be a scalar, it can be any Perl structure. (They will be stringified and
+                  de-stringified automagically).
+
+=cut
+
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
+
+            # init_pipeline.pl makes the best guess of the hive root directory and stores it in EHIVE_ROOT_DIR, if it wasn't already set in the shell
+        'inputfile'     => $ENV{'EHIVE_ROOT_DIR'} . '/t/input_fasta.fa',    # name of the input file, here set to a sample file included with the eHive distribution
+        'input_format'  => 'FASTA',                                         # the expected format of the input file
+
+            # Because this is an example pipeline, we provide a way to slow down execution so
+            # that it can be more easily observed as it runs. The 'take_time' parameter,
+            # specifies how much additional time a step should take before setting itself
+            # to "DONE."
+        'take_time'     => 1,
+    };
+}
+
+
+=head2 pipeline_analyses
+
+    Description : Implements pipeline_analyses() interface method of Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that
+                  defines the structure of the pipeline: analyses, jobs, rules, etc.
+                  Here it defines three analyses:
+                    * 'chunk_sequences' which uses the FastaFactory runnable to split sequences in an input file
+                       into smaller chunks
+
+                    * 'count_atgc' which takes a chunk produced by chunk_sequences, and tallies the number of occurrences
+                       of each base in the sequence(s) in the file
+
+                    * 'calc_overall_percentage' which takes the base count subtotals from all count_atgc jobs and calculates
+                      the overall %GC in the sequence(s) in the original input file. The 'calc_overall_percentage' job is
+                      blocked by a semaphore until all count_atgc jobs have completed.
+
+=cut
+
+sub pipeline_analyses {
+    my ($self) = @_;
+    return [
+        {   -logic_name => 'chunk_sequences',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::FastaFactory',
+            -parameters => {
+                'max_chunk_length'  => 100,                     # amount of sequence, in bases, to include in a single chunk file
+                'output_dir'        => '.',                     # directory to store the chunk files
+                'output_prefix'     => 'gcpct_pipeline_chunk_', # common prefix for the chunk files
+                'output_suffix'     => '.chnk',                 # common suffix for the chunk files
+
+            },
+            -input_ids => [ { } ],  # auto-seed one job with default parameters (coming from pipeline-wide parameters or analysis parameters)
+            -flow_into => {
+                '2->A' => [ 'count_atgc' ],   # will create a semaphored fan of jobs; will use param_stack mechanism to pass parameters around
+                'A->1' => [ 'calc_overall_percentage'  ],   # will create a semaphored funnel job to wait for the fan to complete
+            },
+        },
+
+        {   -logic_name => 'count_atgc',
+            -module     => 'Bio::EnsEMBL::Hive::Examples::GC::RunnableDB::CountATGC',
+            -analysis_capacity  =>  4,  # use per-analysis limiter
+            -flow_into => {
+ 			   1 => ['?accu_name=all_counts&accu_address={}[]{test}&accu_input_variable=count',
+				 '?accu_name=gc_count&accu_address=[]']
+            },
+        },
+
+        {   -logic_name => 'calc_overall_percentage',
+            -module     => 'Bio::EnsEMBL::Hive::Examples::GC::RunnableDB::CalcOverallPercentage',
+            -flow_into => {
+                1 => [ '?table_name=final_result' ], #Flows output into the DB table 'final_result'
+            },
+        },
+     ];
+}
+
+1;

--- a/t/10.pipeconfig/accumulator.t
+++ b/t/10.pipeconfig/accumulator.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+use strict;
+use warnings;
+
+use Test::More;
+use Data::Dumper;
+
+use Bio::EnsEMBL::Hive::Utils::Test qw(init_pipeline runWorker beekeeper get_test_url_or_die safe_drop_database);
+
+# eHive needs this to initialize the pipeline (and run db_cmd.pl)
+$ENV{'EHIVE_ROOT_DIR'} ||= File::Basename::dirname( File::Basename::dirname( File::Basename::dirname( Cwd::realpath($0) ) ) );
+
+my $pipeline_url  = get_test_url_or_die();
+
+{
+    local @INC = @INC;
+    push @INC, $ENV{'EHIVE_ROOT_DIR'}.'/t/10.pipeconfig/';
+    init_pipeline('TestPipeConfig::Accumulator::NullHashKey_conf', $pipeline_url, [], ['pipeline.param[take_time]=100']);
+}
+my $hive_dba = Bio::EnsEMBL::Hive::DBSQL::DBAdaptor->new( -url => $pipeline_url );
+
+# Will submit a worker
+runWorker($pipeline_url, [ '-can_respecialize' ]);
+
+# Check if null hash key error is correct
+my $all_objects = $hive_dba->get_LogMessageAdaptor->fetch_all();
+isnt(index($all_objects->[0]->{'msg'}, 'Null hash key in accumulator, empty curved brackets number 2'), -1, "Correct null hash key error" );
+
+
+
+safe_drop_database( $hive_dba );
+
+done_testing();

--- a/t/10.pipeconfig/accumulator.t
+++ b/t/10.pipeconfig/accumulator.t
@@ -41,9 +41,9 @@ runWorker($pipeline_url, [ '-can_respecialize' ]);
 
 # Check if null hash key error is correct
 my $all_objects = $hive_dba->get_LogMessageAdaptor->fetch_all();
-isnt(index($all_objects->[0]->{'msg'}, 'Null hash key in accumulator, empty curved brackets number 2'), -1, "Correct null hash key error" );
 
-
+my $msg = 'A key in the accumulator had an empty substitution. Bracket \'{}\' pair number 2, substitution from \'{}[]{test}\' to \'{}[]{}\'';
+isnt(index($all_objects->[0]->{'msg'}, $msg), -1, "Detect a null hash key" );
 
 safe_drop_database( $hive_dba );
 


### PR DESCRIPTION
## Use case

When hash key is set to null in dataflow
## Description

When hashkey is set to null, next job fails to read it, but it should be that current job fails to read it

## Possible Drawbacks

Not found

## Testing

_Have you added/modified unit tests to test the changes?_

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Yes
