### PR TITLE
[generate_timeline] Define custom categories to group analyses / resource-classes

### DIFF
--- a/scripts/dev/generate_timeline_example_key_transform_file.pl
+++ b/scripts/dev/generate_timeline_example_key_transform_file.pl
@@ -1,0 +1,69 @@
+
+use strict;
+use warnings;
+
+# Transform a Compara resource class into a category name according to the
+# memory requirement.
+
+sub get_key_name {
+    my $resource_class = shift;
+
+    my $display_name = $resource_class->display_name;
+    my $memory_req = $display_name;
+
+    # Convert special names to the standard nomenclature
+    $memory_req = '250Mb_job' if $display_name eq 'default';
+    $memory_req = '250Mb_job' if $display_name eq 'urgent';
+    $memory_req = '2Gb_job' if $display_name eq 'msa';
+    $memory_req = '8Gb_job' if $display_name eq 'msa_himem';
+
+    # Remove stuff we don't need
+    $memory_req =~ s/_(job|mpi|big_tmp)//g;
+    $memory_req =~ s/_\d+(_hour|min|c$)//g;
+
+    # Convert to GBs
+    $memory_req =~ s/Gb$//;
+    if ($memory_req =~ /^(\d+)Mb$/) {
+        $memory_req = $1/1000;
+    } elsif ($memory_req =~ /^mem(\d+)$/) {
+        $memory_req = $1/1000;
+    }
+
+    if ($memory_req < 1) {
+        return '<1';
+    } elsif ($memory_req <= 4) {
+        return '1-4';
+    } elsif ($memory_req <= 8) {
+        return '5-8';
+    } elsif ($memory_req <= 16) {
+        return '9-16';
+    } elsif ($memory_req <= 32) {
+        return '17-32';
+    } elsif ($memory_req <= 128) {
+        return '33-128';
+    } else {
+        return 'bigmem';
+    }
+}
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+
+=head1 CONTACT
+
+Please subscribe to the eHive mailing list:  http://listserver.ebi.ac.uk/mailman/listinfo/ehive-users  to discuss eHive-related questions or to be notified of our updates
+
+=cut
+
+1;

--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -674,6 +674,7 @@ what should be displayed on the y-axis. Allowed values are "workers" (default), 
 the path to a Perl script that defines a function named "get_key_name". The function is used to provide custom key names for analyses and
 resource classes instead of their own display names. The function must take the object (Analysis or ResourceClass) as a sole argument and
 return a (non empty) string.
+See scripts/dev/generate_timeline_example_key_transform_file.pl for an example.
 
 =item --resolution <integer>
 

--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -209,7 +209,7 @@ sub main {
             ? 'SELECT when_submitted, when_started, when_finished, worker_id, resource_class_id, analysis_id FROM worker LEFT JOIN role USING (worker_id)'
             : 'SELECT when_submitted, when_born, when_died, worker_id, resource_class_id FROM worker';
         my @tmp_dates = @{$hive_dbc->selectall_arrayref($sql)};
-        warn scalar(@tmp_dates), " rows\n" if $verbose;
+        warn scalar(@tmp_dates), " rows in ", $hive_dbc->dbname, "\n" if $verbose;
 
         foreach my $db_entry (@tmp_dates) {
             my ($when_submitted, $when_born, $when_died, $worker_id, $resource_class_id, $analysis_id) = @$db_entry;

--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -589,7 +589,7 @@ You can optionally ask the script to generate an image with Gnuplot.
     generate_timeline.pl -url mysql://username:secret@hostname:port/database -mode memory -output timeline_memory.png
 
         # Draw the CPU-usage timeline across several databases
-    generate_timeline.pl -url mysql://username:secret@hostname:port/database -url mysql://username:secret@hostname:port/another_database -mode cpu -output timeline_cpu.png
+    generate_timeline.pl -url mysql://username:secret@hostname:port/database -url mysql://username:secret@hostname:port/another_database -mode cores -output timeline_cpu.png
 
 
 =head1 OPTIONS

--- a/scripts/generate_timeline.pl
+++ b/scripts/generate_timeline.pl
@@ -247,6 +247,7 @@ sub main {
                 add_event(\%layers, $key_value, $when_submitted, $when_born, 'length_by_60', $resolution);
             }
         }
+        $hive_dbc->disconnect_if_idle;
     }
     warn "Events recorded: ", scalar(keys %events), " ", scalar(keys %layers), "\n" if $verbose;
 


### PR DESCRIPTION
## Use case

James asked us to extract farm usage statistics for the migration to Codon, for some memory classes. I have used `generate_timeline.pl` to get the data for Compara, but did a few changes to allow defining the custom classes he wanted to have (which in our cases consisted of grouping some of our resource classes together).

## Description

`generate_timeline.pl` accepts a new parameter: a script that defines a function named `get_key_name` that, given an Analysis or a ResourceClass object, returns a category name for this object. Objects that have the same category name are grouped together and displayed with the name given. I have added the function that I used for Compara as an example.

I also took the opportunity to rename several variables for clarity.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

There are no unit test for `generate_timeline.pl` and I didn't want to embark on writing one

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
