### PR TITLE
Cleaner python wrapper

### DIFF
--- a/wrappers/python3/wrapper
+++ b/wrappers/python3/wrapper
@@ -40,7 +40,6 @@ def do_run():
 
 def do_build():
     print("Nothing to do")
-    return
 
 ## And here we select the mode
 

--- a/wrappers/python3/wrapper
+++ b/wrappers/python3/wrapper
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 
-import os
 import sys
 
 import eHive

--- a/wrappers/python3/wrapper
+++ b/wrappers/python3/wrapper
@@ -67,7 +67,7 @@ if mode not in available_modes:
 if len(sys.argv)-2 < len(available_modes[mode][1]):
     usage('Not enough arguments for mode "' + mode + '". Expecting: ' + ' '.join(available_modes[mode][1]))
 if len(sys.argv)-2 > len(available_modes[mode][1]):
-    usage('Too many arguments for mode "' + mode + '". Expecting: ' + (' '.join(available_modes[mode][1]) if len(available_modes[mode][1]) else '(none)'))
+    usage('Too many arguments for mode "' + mode + '". Expecting: ' + (' '.join(available_modes[mode][1]) if available_modes[mode][1] else '(none)'))
 
 available_modes[mode][0]()
 

--- a/wrappers/python3/wrapper
+++ b/wrappers/python3/wrapper
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 
+import collections
 import sys
 
 import eHive
@@ -43,17 +44,18 @@ def do_build():
 
 ## And here we select the mode
 
+WrapperMode = collections.namedtuple('WrapperMode', ['function', 'args'])
 available_modes = {
-        'version' : (do_version, []),
-        'build'   : (do_build, []),
-        'check_exists' : (do_check_exists, ['module_name']),
-        'run'     : (do_run, ['module_name', 'fd_in', 'fd_out', 'debug'])
+        'version' : WrapperMode(do_version, []),
+        'build'   : WrapperMode(do_build, []),
+        'check_exists' : WrapperMode(do_check_exists, ['module_name']),
+        'run'     : WrapperMode(do_run, ['module_name', 'fd_in', 'fd_out', 'debug'])
     }
 
 def usage(msg):
     error = "Command-line error: " + msg + "\nUsage: \n"
-    for (mode, (_, args)) in available_modes.items():
-        error += "\t" + " ".join([sys.argv[0], mode] + args) + "\n"
+    for (mode, impl) in available_modes.items():
+        error += "\t" + " ".join([sys.argv[0], mode] + impl.args) + "\n"
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -63,11 +65,11 @@ if len(sys.argv) == 1:
 mode = sys.argv[1]
 if mode not in available_modes:
     usage('Unknown mode "{0}"'.format(mode))
+impl = available_modes[mode]
 
-if len(sys.argv)-2 < len(available_modes[mode][1]):
-    usage('Not enough arguments for mode "' + mode + '". Expecting: ' + ' '.join(available_modes[mode][1]))
-if len(sys.argv)-2 > len(available_modes[mode][1]):
-    usage('Too many arguments for mode "' + mode + '". Expecting: ' + (' '.join(available_modes[mode][1]) if available_modes[mode][1] else '(none)'))
-
-available_modes[mode][0]()
+if len(sys.argv)-2 < len(impl.args):
+    usage('Not enough arguments for mode "' + mode + '". Expecting: ' + ' '.join(impl.args))
+if len(sys.argv)-2 > len(impl.args):
+    usage('Too many arguments for mode "' + mode + '". Expecting: ' + (' '.join(impl.args) if impl.args else '(none)'))
+impl.function()
 


### PR DESCRIPTION
## Use case

More changes I should have put into #166 . They make `wrappers/python3/wrapper` more compliant with `pylint` (although still not 100%) and more Pythonic.

## Description

The biggest change is to use a `namedtuple` to hold the details about each mode of the wrapper instead of a regular tuple. This means that the data can be accessed through named properties `function` and `args` rather than indices `[0]` and `[1]`.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

The wrapper is covered by several tests

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
