### PR TITLE
Various bug fixes in tweak_pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -646,20 +646,14 @@ sub apply_tweaks {
                 if( $attrib_name eq 'resource_class' ) {
 
                     if($operator eq '?') {
-                        if(my $old_value = $analysis->resource_class) {
-                            print "Tweak.Show    \tanalysis[$analysis_name].resource_class ::\t".$old_value->name."\n";
-                        } else {
-                            print "Tweak.Show    \tanalysis[$analysis_name].resource_class ::\t(missing value)\n";
-                        }
+                        my $old_value = $analysis->resource_class;
+                        print "Tweak.Show    \tanalysis[$analysis_name].resource_class ::\t".$old_value->name."\n";
                     } elsif($operator eq '#') {
-                        print "Tweak.Error   \tDeleting of ResourceClasses is not supported\n";
+                        print "Tweak.Error   \tDeleting of an Analysis' resource-class is not supported\n";
                     } else {
 
-                        if(my $old_value = $analysis->resource_class) {
-                            print "Tweak.Changing\tanalysis[$analysis_name].resource_class ::\t".$old_value->name." --> $new_value_str\n";
-                        } else {
-                            print "Tweak.Adding  \tanalysis[$analysis_name].resource_class ::\t(missing value) --> $new_value_str\n";    # do we ever NOT have resource_class set?
-                        }
+                        my $old_value = $analysis->resource_class;
+                        print "Tweak.Changing\tanalysis[$analysis_name].resource_class ::\t".$old_value->name." --> $new_value_str\n";
 
                         my $resource_class;
                         if($resource_class = $self->collection_of( 'ResourceClass' )->find_one_by( 'name', $new_value )) {

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -658,15 +658,12 @@ sub apply_tweaks {
                         my $resource_class;
                         if($resource_class = $self->collection_of( 'ResourceClass' )->find_one_by( 'name', $new_value )) {
                             print "Tweak.Found   \tresource_class[$new_value_str]\n";
+                            $analysis->resource_class( $resource_class );
+                            $need_write = 1;
                         } else {
-                            print "Tweak.Adding  \tresource_class[$new_value_str]\n";
+                            print "Tweak.Error   \t'$new_value_str' is not a known resource-class\n";
 
-                            ($resource_class) = $self->add_new_or_update( 'ResourceClass',   # NB: add_new_or_update returns a list
-                                'name'  => $new_value,
-                            );
                         }
-                        $analysis->resource_class( $resource_class );
-                        $need_write = 1;
                     }
 
                 } elsif( $attrib_name eq 'dbID' ) {

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -707,6 +707,16 @@ sub apply_tweaks {
 
             } else {
 
+                # Auto-vivification of the ResourceClass
+                unless (@$resource_classes) {
+                    print "Tweak.Adding  \tresource_class[$rc_pattern]\n";
+                    my ($resource_class) = $self->add_new_or_update( 'ResourceClass',   # NB: add_new_or_update returns a list
+                        'name'  => $rc_pattern,
+                    );
+                    push @$resource_classes, $resource_class;
+                    $need_write = 1;
+                }
+
                 my $new_value = destringify( $new_value_str );
                 my ($new_submission_cmd_args, $new_worker_cmd_args) = (ref($new_value) eq 'ARRAY') ? @$new_value : ($new_value, '');
 

--- a/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
+++ b/modules/Bio/EnsEMBL/Hive/HivePipeline.pm
@@ -675,6 +675,9 @@ sub apply_tweaks {
                         $need_write = 1;
                     }
 
+                } elsif( $attrib_name eq 'dbID' ) {
+                    print "Tweak.Error   \tChanging the dbID of an Analysis is not supported\n";
+
                 } elsif($analysis->can($attrib_name)) {
                     my $old_value = stringify($analysis->$attrib_name());
 


### PR DESCRIPTION
## Use case

This is a collection of bugfixes in `tweak_pipeline.pl`, one of them being https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3002

## Description

The commit messages are self-explanatory. In summary
- don't allow changing the dbID of an analysis (that would fail anyway because of the foreign key from `analysis_stats`)
- don't assume `analysis.resourece_class_id` can be NULL. It can't
- don't allow associating an analysis to a non-existing resource-class
- make the `resource_class[XXX].YYY` create a new resource-class `XXX` if it doesn't exist, to host the resource-description of `YYY`

Note: there is a minor conflict when merging this into `version/2.5` because the `elsif ... dbID` is at the same place of the `elsif ... is_excluded`, but that's relatively straightforward to fix. On the other hand, the merge into `master` is much trickier because the error handling of `HivePipeline::apply_tweaks` has completely changed (#62). I'll make a separate pull-request for `master` (where I put the `elsif` of `dbID` _after_ the one of `is_excluded`).

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

There is no test for `tweak_pipeline.pl` on `version/2.4`, but there is one on `version/2.5`

_Have you run the entire test suite and no regression was detected?_
