### PR TITLE
Update README.md to reflect end of maintainence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 eHive
 =====
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-hive.svg?branch=version/2.3)](https://travis-ci.org/Ensembl/ensembl-hive)
-[![Coverage Status](https://coveralls.io/repos/Ensembl/ensembl-hive/badge.svg?branch=version/2.3&service=github)](https://coveralls.io/github/Ensembl/ensembl-hive?branch=version/2.3)
+---
 
-[travis]: https://travis-ci.org/Ensembl/ensembl-hive
-[coveralls]: https://coveralls.io/r/Ensembl/ensembl-hive
+:warning: This branch is not maintained any more ! :warning:
+
+---
+
 
 
 eHive is a system for running computation pipelines on distributed computing resources - clusters, farms or grids.


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

Update documentation to indicate the end of life of version/2.3 (and version/2.4 via cascade merge)

## Description

Adds a warning to README.md, and removes the Travis and Coveralls badges

## Possible Drawbacks



## Testing

_Have you added/modified unit tests to test the changes?_

N/A, but this is a good reminder to check for and remove any cron jobs to test version/2.3 and version/2.4 from Travis 

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

N/A