### PR TITLE
Checks for ENSEMBL_ROOT_DIR and ENSEMBL_CSV_ROOT_DIR

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
             #   [bash]      export -n ENSEMBL_CVS_ROOT_DIR  # will stop exporting, but the value in current shell stays as it was
             #   [tcsh]      unsetenv ENSEMBL_CVS_ROOT_DIR   # will destroy the variable even in current shell, and stop exporting
 
-        'ensembl_cvs_root_dir'  => $ENV{'ENSEMBL_ROOT_DIR'} || $self->o('ensembl_root_dir') || $ENV{'ENSEMBL_CVS_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),    # it will make sense to set this variable if you are going to use ehive with ensembl
+	'ensembl_cvs_root_dir'  => $self->o('ensembl_root_dir') || $self->o('ensembl_cvs_root_dir') || $ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'},    # it will make sense to set this variable if you are going to use ehive with ensembl
 
         'ensembl_release'       => Bio::EnsEMBL::ApiVersion::software_version(),                        # snapshot of EnsEMBL Core API version. Please do not change if not sure.
         'rel_suffix'            => '',                                                                  # an empty string by default, a letter otherwise

--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
             #   [bash]      export -n ENSEMBL_CVS_ROOT_DIR  # will stop exporting, but the value in current shell stays as it was
             #   [tcsh]      unsetenv ENSEMBL_CVS_ROOT_DIR   # will destroy the variable even in current shell, and stop exporting
 
-        'ensembl_cvs_root_dir'  => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),    # it will make sense to set this variable if you are going to use ehive with ensembl
+        'ensembl_cvs_root_dir'  => $ENV{'ENSEMBL_ROOT_DIR'} || $self->o('ensembl_root_dir') || $ENV{'ENSEMBL_CVS_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),    # it will make sense to set this variable if you are going to use ehive with ensembl
 
         'ensembl_release'       => Bio::EnsEMBL::ApiVersion::software_version(),                        # snapshot of EnsEMBL Core API version. Please do not change if not sure.
         'rel_suffix'            => '',                                                                  # an empty string by default, a letter otherwise


### PR DESCRIPTION
## Description

EnsemblGeneric_conf checks for installed Ensembl modules in $ENSEMBL_CVS_ROOT_DIR, but these modules will be stored in $ENSEMBL_ROOT_DIR on Codon. This change ensures that we check both directories, with the following priorities in place:

- 'ensembl_root_dir' passed on the command line
- 'ensembl_cvs_root_dir' passed on the command line
- $ENSEMBL_ROOT_DIR environment variable
- $ENSEMBL_CVS_ROOT_DIR environment variable

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3735

## Possible Drawbacks

This fix gives values passed through the command line priority over environment variables, but it was the reverse before. Thus, this fix changes the behavior of the code so users should be aware of that. However, the reverse of this was deemed a bug and users have asked for this fix so all should be good.

## Testing

_Have you added/modified unit tests to test the changes?_

No (I don't think there is any test that checks this param)
