### PR TITLE
EnsemblGeneric_conf checks for ENSEMBL_ROOT_DIR and ENSEMBL_CSV_ROOT_DIR

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
             #   [bash]      export -n ENSEMBL_CVS_ROOT_DIR  # will stop exporting, but the value in current shell stays as it was
             #   [tcsh]      unsetenv ENSEMBL_CVS_ROOT_DIR   # will destroy the variable even in current shell, and stop exporting
 
-        'ensembl_cvs_root_dir'  => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),    # it will make sense to set this variable if you are going to use ehive with ensembl
+        'ensembl_cvs_root_dir'  => $ENV{'ENSEMBL_ROOT_DIR'} || $self->o('ensembl_root_dir') || $ENV{'ENSEMBL_CVS_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),    # it will make sense to set this variable if you are going to use ehive with ensembl
 
         'ensembl_release'       => Bio::EnsEMBL::ApiVersion::software_version(),                        # snapshot of EnsEMBL Core API version. Please do not change if not sure.
         'rel_suffix'            => '',                                                                  # an empty string by default, a letter otherwise


### PR DESCRIPTION
## Use case

Codon guidelines call for the Ensembl installation path to be stored in $ENSEMBL_ROOT_DIR. EnsemblGeneric_conf needs to now check this before checking $ENSEMBL_CVS_ROOT_DIR in case it is being run on Codon.

## Description

This change ensures that EnsemblGeneric_conf checks both $ENSEMBL_ROOT_DIR and $ENSEMBL_CVS_ROOT_DIR, giving priority to $ENSEMBL_ROOT_DIR and uses whichever one it finds first.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3735

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No (I don't think there is any test that checks this)
