### PR TITLE
rework setting of ensembl_cvs_root_dir in response to user bug report

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
@@ -61,8 +61,12 @@ sub default_options {
             #   [bash]      export -n ENSEMBL_CVS_ROOT_DIR  # will stop exporting, but the value in current shell stays as it was
             #   [tcsh]      unsetenv ENSEMBL_CVS_ROOT_DIR   # will destroy the variable even in current shell, and stop exporting
 
-	'ensembl_cvs_root_dir'  => $self->o('ensembl_root_dir') || $self->o('ensembl_cvs_root_dir') || $ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'},    # it will make sense to set this variable if you are going to use ehive with ensembl
-
+            # have to be careful not to check for $self->o('ensembl_cvs_root_dir') unless no env variable is set, or else
+            # it will cause options missing errors. Also, the $self->o() system doesn't support optional options at
+            # the time of this commit, so we can only have one of ensembl_root_dir or ensembl_cvs_root_dir, otherwise
+            # there would always be an options missing error. We choose ensembl_cvs_root_dir for backwards compatibility.
+        'ensembl_cvs_root_dir'  => defined($ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'}) ?
+             $ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'} : $self->o('ensembl_cvs_root_dir'),
         'ensembl_release'       => Bio::EnsEMBL::ApiVersion::software_version(),                        # snapshot of EnsEMBL Core API version. Please do not change if not sure.
         'rel_suffix'            => '',                                                                  # an empty string by default, a letter otherwise
         'rel_with_suffix'       => $self->o('ensembl_release').$self->o('rel_suffix'),


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

Compara reports that the recent change to how ensembl_cvs_root_dir is set in EnsemblGeneric.conf is buggy. In particular, we can't check `$self->o('ensembl_cvs_root_dir')` first, because it will lead to a "The following options are missing:" error if it is not set.

(This explains why the previous implementation checked the `$self->o()` second - to take advantage of lazy evaluation in the if statement).

## Description

Setting 'ensembl_cvs_root_dir' has been reworked to make sure that the `$self->o()` is only called if there are no relevant environment variables set, thus making sure that an error message only appears of there is no possible source of ensembl_cvs_root_dir.

## Possible Drawbacks

It's impossible within the current system to check for both `$self->o('ensembl_cvs_root_dir')` and `$self->o('ensembl_root_dir')`, so the second option has been dropped. As this feature has been available for less than 24 hours, it's unlikely anyone will miss it

## Testing

_Have you added/modified unit tests to test the changes?_

No, this hotfix needs to be deployed quickly

_If so, do the tests pass/fail?_

I have tested this with a toy pipeline based on EnsemblGeneric_conf, with combinations of environment variables and passing ensembl_cvs_root_dir as a command line option, and it works as expected. There is no "The following options are missing:" error as long as one of the `$ENSEMBL_[CVS]_ROOT_DIR` environment variables are set.

_Have you run the entire test suite and no regression was detected?_
