### PR TITLE
update bacct command line for codon compatibility [ENSCORESW-3805]

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -25,9 +25,9 @@ return something like undef to tell the caller that no operation was done.
  GarbageCollector:       [LSF/EBI Meadow:]       LOST:20
 
  GarbageCollector:       Discovered 20 lost LSF Workers
- LSF::parse_report_source_line( "bacct -l '4126850[15]' '4126850[6]' '4126835[24]' '4126850[33]' '4126835[10]' '4126835[39]' '4126850[23]' '4126835[3]' '4126835[19]' '4126835[31]' '4126835[40]' '4126835[41]' '4126850[5]' '4126850[41]' '4126850[2]' '4126850[3]' '4126835[5]' '4126835[33]' '4126850[7]' '4126850[42]'" )
+ LSF::parse_report_source_line( "bacct -f - -l '4126850[15]' '4126850[6]' '4126835[24]' '4126850[33]' '4126835[10]' '4126835[39]' '4126850[23]' '4126835[3]' '4126835[19]' '4126835[31]' '4126835[40]' '4126835[41]' '4126850[5]' '4126850[41]' '4126850[2]' '4126850[3]' '4126835[5]' '4126835[33]' '4126850[7]' '4126850[42]'" )
  ls_getclustername(): Slave LIM configuration is not ready yet. Please give file name.
- Could not read from 'bacct -l '4126850[15]' '4126850[6]' '4126835[24]' '4126850[33]' '4126835[10]' '4126835[39]' '4126850[23]' '4126835[3]' '4126835[19]' '4126835[31]' '4126835[40]' '4126835[41]' '4126850[5]' '4126850[41]' '4126850[2]' '4126850[3]' '4126835[5]' '4126835[33]' '4126850[7]' '4126850[42]''. Received the error 255
+ Could not read from 'bacct -f - -l '4126850[15]' '4126850[6]' '4126835[24]' '4126850[33]' '4126835[10]' '4126835[39]' '4126850[23]' '4126835[3]' '4126835[19]' '4126835[31]' '4126835[40]' '4126835[41]' '4126850[5]' '4126850[41]' '4126850[2]' '4126850[3]' '4126835[5]' '4126835[33]' '4126850[7]' '4126850[42]''. Received the error 255
 
 =back
 
@@ -322,7 +322,7 @@ sub get_report_entries_for_process_ids {
 
     unless ($self->config_get('AccountingDisabled')) {
         while (my $pid_batch = join(' ', map { "'$_'" } splice(@_, 0, 20))) {  # can't fit too many pids on one shell cmdline
-            my $cmd = "bacct -l $pid_batch";
+            my $cmd = "bacct -f - -l $pid_batch";
 
 #           warn "LSF::get_report_entries_for_process_ids() running cmd:\n\t$cmd\n";
 
@@ -348,7 +348,7 @@ sub get_report_entries_for_time_interval {
         my $to_timepiece = Time::Piece->strptime($to_time, '%Y-%m-%d %H:%M:%S') + 2*ONE_MINUTE;
         $to_time = $to_timepiece->strftime('%Y/%m/%d/%H:%M');
 
-        my $cmd = "bacct -l -C $from_time,$to_time ".($username ? "-u $username" : '');
+        my $cmd = "bacct -f - -l -C $from_time,$to_time ".($username ? "-u $username" : '');
 
 #        warn "LSF::get_report_entries_for_time_interval() running cmd:\n\t$cmd\n";
 

--- a/t/04.meadow/lsf.t
+++ b/t/04.meadow/lsf.t
@@ -208,13 +208,13 @@ my $expected_bacct = {
 
 $lsf_meadow->config_set("AccountingDisabled", 0);
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-l 34 56[7]';
+    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l 34 56[7]';
     my $h = $lsf_meadow->get_report_entries_for_process_ids(34, '56[7]');
     is_deeply($h, $expected_bacct, 'Got bacct output');
 }, 'Can call bacct on process_ids');
 
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-l -C 2020/10/11/12:23,2020/12/12/23:58 -u kb3';
+    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l -C 2020/10/11/12:23,2020/12/12/23:58 -u kb3';
     my $h = $lsf_meadow->get_report_entries_for_time_interval('2020-10-11 12:23:45', '2020-12-12 23:56:59', 'kb3');
     is_deeply($h, $expected_bacct, 'Got bacct output');
 }, 'Can call bacct on a date range');
@@ -222,13 +222,13 @@ lives_and( sub {
 
 $lsf_meadow->config_set("AccountingDisabled", 1);
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-l 34 56[7]';
+    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l 34 56[7]';
     my $h = $lsf_meadow->get_report_entries_for_process_ids(34, '56[7]');
     is_deeply($h, {}, 'No bacct output when accounting disabled');
 }, 'Suppressed bacct when AccountingDisabled when checking process_ids');
 
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-l -C 2015/10/11/12:23,2015/12/12/23:58 -u kb3';
+    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l -C 2015/10/11/12:23,2015/12/12/23:58 -u kb3';
     my $h = $lsf_meadow->get_report_entries_for_time_interval('2015-10-11 12:23:45', '2015-12-12 23:56:59', 'kb3');
     is_deeply($h, {}, 'No bacct output when accounting disabled');
 }, 'Suppressed bacct when AccountingDisabled when checking a date range');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

Systems have changed the LSF configuration on codon so that bacct now requires the `-f` option to work. `-f` does no harm on noah. This change makes eHive compatible with codon again.

## Description

bacct commands have `-f -` added

## Possible Drawbacks

Systems may change LSF configuration again, requiring another change.

## Testing

Yes 04.meadow/lsf.t

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_

Yes