### PR TITLE
Making bacct options configurable according to cluster

### DIFF
--- a/hive_config.json
+++ b/hive_config.json
@@ -36,6 +36,9 @@
             "EBI" : {
                 "SubmissionOptions"  : "",
                 "TotalRunningWorkersMax"    : 10000
+            },
+            "codon" : {
+                "BacctExtraOptions"  : "-f -"
             }
         },
         "SGE" : {

--- a/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/LSF.pm
@@ -322,7 +322,8 @@ sub get_report_entries_for_process_ids {
 
     unless ($self->config_get('AccountingDisabled')) {
         while (my $pid_batch = join(' ', map { "'$_'" } splice(@_, 0, 20))) {  # can't fit too many pids on one shell cmdline
-            my $cmd = "bacct -f - -l $pid_batch";
+            my $bacct_opts = $self->config_get('BacctExtraOptions') || "";
+            my $cmd = "bacct $bacct_opts -l $pid_batch";
 
 #           warn "LSF::get_report_entries_for_process_ids() running cmd:\n\t$cmd\n";
 
@@ -348,7 +349,8 @@ sub get_report_entries_for_time_interval {
         my $to_timepiece = Time::Piece->strptime($to_time, '%Y-%m-%d %H:%M:%S') + 2*ONE_MINUTE;
         $to_time = $to_timepiece->strftime('%Y/%m/%d/%H:%M');
 
-        my $cmd = "bacct -f - -l -C $from_time,$to_time ".($username ? "-u $username" : '');
+        my $bacct_opts = $self->config_get('BacctExtraOptions') || "";
+        my $cmd = "bacct $bacct_opts -l -C $from_time,$to_time ".($username ? "-u $username" : '');
 
 #        warn "LSF::get_report_entries_for_time_interval() running cmd:\n\t$cmd\n";
 

--- a/t/04.meadow/lsf.t
+++ b/t/04.meadow/lsf.t
@@ -207,14 +207,15 @@ my $expected_bacct = {
 };
 
 $lsf_meadow->config_set("AccountingDisabled", 0);
+my $bacct_opts = $lsf_meadow->config_get('BacctExtraOptions') || "";
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l 34 56[7]';
+    local $ENV{EHIVE_EXPECTED_BACCT} = $bacct_opts.'-l 34 56[7]';
     my $h = $lsf_meadow->get_report_entries_for_process_ids(34, '56[7]');
     is_deeply($h, $expected_bacct, 'Got bacct output');
 }, 'Can call bacct on process_ids');
 
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l -C 2020/10/11/12:23,2020/12/12/23:58 -u kb3';
+    local $ENV{EHIVE_EXPECTED_BACCT} = $bacct_opts.'-l -C 2020/10/11/12:23,2020/12/12/23:58 -u kb3';
     my $h = $lsf_meadow->get_report_entries_for_time_interval('2020-10-11 12:23:45', '2020-12-12 23:56:59', 'kb3');
     is_deeply($h, $expected_bacct, 'Got bacct output');
 }, 'Can call bacct on a date range');
@@ -222,13 +223,13 @@ lives_and( sub {
 
 $lsf_meadow->config_set("AccountingDisabled", 1);
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l 34 56[7]';
+    local $ENV{EHIVE_EXPECTED_BACCT} = $bacct_opts.'-l 34 56[7]';
     my $h = $lsf_meadow->get_report_entries_for_process_ids(34, '56[7]');
     is_deeply($h, {}, 'No bacct output when accounting disabled');
 }, 'Suppressed bacct when AccountingDisabled when checking process_ids');
 
 lives_and( sub {
-    local $ENV{EHIVE_EXPECTED_BACCT} = '-f - -l -C 2015/10/11/12:23,2015/12/12/23:58 -u kb3';
+    local $ENV{EHIVE_EXPECTED_BACCT} = $bacct_opts.'-l -C 2015/10/11/12:23,2015/12/12/23:58 -u kb3';
     my $h = $lsf_meadow->get_report_entries_for_time_interval('2015-10-11 12:23:45', '2015-12-12 23:56:59', 'kb3');
     is_deeply($h, {}, 'No bacct output when accounting disabled');
 }, 'Suppressed bacct when AccountingDisabled when checking a date range');


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

The bacct command takes in an extra option (-f -) on Codon. Adding this option doesn't currently hurt anything on Noah but future additions might. Thus, it is better to make these extra options configurable per cluster in case some more tuning is needed for the bacct command.

JIRA ticket: [ENSCORESW-3806](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3806)

## Description

Added a new config option "BacctExtraOptions" which has the value if "-f -" for codon. This config value is read the placed in the bacct command in addition to other options.

## Possible Drawbacks

None

## Testing

The existing test 04.meadow/lsf.t was modified to read the bacct extra options and it is succeeding with this change.
