### PR TITLE
Bugfix/rtd build config

### DIFF
--- a/docs/rtd_upgrade.sh
+++ b/docs/rtd_upgrade.sh
@@ -31,7 +31,6 @@ mkdir packages
 cd packages
 # List of extra packages we need
 apt-get download \
-     libdbi-perl \
      libdbd-sqlite3-perl \
      libjson-xs-perl \
      libjson-perl \
@@ -45,6 +44,9 @@ apt-get download \
      doxypy \
      libproc-daemon-perl \
 
+# manual download because rtd hasn't updated apt-cache
+echo http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbi-perl/libdbi-perl_1.640-1_amd64.deb \
+  | xargs -n 1 curl -O
 
 mkdir ../root
 for i in *.deb; do dpkg -x "$i" ../root/; done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-sphinxcontrib-doxylink==1.3
+sphinxcontrib-doxylink
+doxypypy


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

doc builds on readthedocs.org have broken. This is because the apt-cache in their vm is out of date, preventing installation of libdbi-perl using apt-get

## Description

We convert to downloading libdbi-perl manually for install. We also remove the version restriction on sphinxcontrib-doxylink

## Possible Drawbacks

At some point, readthedocs will upgrade their vm, requiring us to change which libdbi-perl .deb we download. 

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

Have built docs on readthedocs.org with this configuration (in project ehive-docbuild-test), and build is successful

_Have you run the entire test suite and no regression was detected?_

N/A
