### PR TITLE
Display pipeline name and url at each iteration

### DIFF
--- a/scripts/beekeeper.pl
+++ b/scripts/beekeeper.pl
@@ -572,6 +572,12 @@ sub run_autonomously {
 
         print("\nBeekeeper : loop #$iteration ======================================================\n");
 
+        my $pipeline_name = $pipeline->hive_pipeline_name;
+        if ($pipeline_name) {
+          print "\nPipeline name: $pipeline_name";
+        }
+        print "\nPipeline URL: ".$self->{'url'}."\n\n";
+
         $queen->check_for_dead_workers($valley, 0) unless $self->{'read_only'};
 
         # this section is where the beekeeper decides whether or not to stop looping


### PR DESCRIPTION
## Use case

When running beekeeper in -loop mode, the pipeline name is only displayed at the start. For users who run multiple pipelines at the same time, it can be confusing as to what pipeline a specific beekeeper is looping for, especially if it has been running for a while and has gone through many loops. This feature helps with that by displaying the pipeline name and url at every iteration.

## Description

Adding the current pipeline name and url at the start of every beekeeper loop.

## Possible Drawbacks

None

## Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_
