### PR TITLE
ignore failures in coverage testing

### DIFF
--- a/scripts/dev/travis_run_tests.sh
+++ b/scripts/dev/travis_run_tests.sh
@@ -46,7 +46,9 @@ if [[ ($rt -eq 0) && ($rtp -eq 0) && ($rtj -eq 0) ]]; then
     fi
     cover --nosummary -report codecov
   fi
-  exit $?
+  # ignore any failures from coverage testing. Due to the if, can only reach this
+  # point if there were no test failures
+  exit 0
 else
   exit 255
 fi


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [development guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#ehive-development-in-a-nutshell) for eHive; remember in particular:
    - Do not modify code without testing for regression.
    - Provide simple unit tests to test the changes.
    - If you change the database schema, please follow the instructions [for schema changes in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#schema-changes).
    - If you change the schema, meadow, or guest language interfaces, please follow the scheme [for internal versioning in the developer guidelines](https://ensembl-hive.readthedocs.io/en/master/dev/development_guidelines.html#internal-versioning).
    - The PR must not fail unit testing.

## Use case

We were seeing test failures due to issues with codecov.io. Although these failures appear to be transient and rare, it is better if they are ignored for the purposes of determining if a branch has passed testing. See ENSCORESW-3863

## Description

Change the testrunner travis_run_tests.sh to ignore failures that happen when publishing coverage output to coveralls and codecov

## Possible Drawbacks

Coverage testing could fail for a while and it would not be noticed.

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes

In addition, this change was tested by inserting a fake test failure, pushing to GitHub, and verifying that travis reported the test failure. This fake test failure was then removed before opening this PR.