### PR TITLE
Tiny tweaks related to migration to Codon

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/EnsemblGeneric_conf.pm
@@ -67,6 +67,7 @@ sub default_options {
             # there would always be an options missing error. We choose ensembl_cvs_root_dir for backwards compatibility.
         'ensembl_cvs_root_dir'  => defined($ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'}) ?
              $ENV{'ENSEMBL_ROOT_DIR'} || $ENV{'ENSEMBL_CVS_ROOT_DIR'} : $self->o('ensembl_cvs_root_dir'),
+        'ensembl_root_dir'      => $self->o('ensembl_cvs_root_dir'),
         'ensembl_release'       => Bio::EnsEMBL::ApiVersion::software_version(),                        # snapshot of EnsEMBL Core API version. Please do not change if not sure.
         'rel_suffix'            => '',                                                                  # an empty string by default, a letter otherwise
         'rel_with_suffix'       => $self->o('ensembl_release').$self->o('rel_suffix'),

--- a/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
+++ b/modules/Bio/EnsEMBL/Hive/PipeConfig/HiveGeneric_conf.pm
@@ -204,10 +204,10 @@ sub resource_classes {
     return {
 ## No longer supported resource declaration syntax:
 #        1 => { -desc => 'default',  'LSF' => '' },
-#        2 => { -desc => 'urgent',   'LSF' => '-q yesterday' },
+#        2 => { -desc => 'urgent',   'LSF' => '-q production' },
 ## Currently supported resource declaration syntax:
         'default' => { 'LSF' => '' },
-        'urgent'  => { 'LSF' => '-q yesterday' },
+        'urgent'  => { 'LSF' => '-q production' },
     };
 }
 


### PR DESCRIPTION
## Description
Part of the instructions for Ensembl in our move to Codon were to start using `ENSEMBL_ROOT_DIR`, so whilst support for the previous variable should remain, I believe having this can be useful in eHive as well. Furthermore, `yesterday` queue is something of the past (Noah), and I guess the most adequate replacement would be `production`.

## Possible Drawbacks
None.

## Testing
This code has been used by Compara and part of Metazoa for several releases without issues.

## Note
Merging these into `main` branch would be nice as well :)