### PR TITLE
Remove redundant message

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
@@ -516,8 +516,6 @@ sub submit_workers_return_meadow_pids {
          #
          $return_value = [ $slurm_job_id ]; 
        } 
-          
-       print "SLURM: Submitted job ids: " . join(" ", @$return_value)."\n";  
 
        return $return_value; 
        #return ($array_required ? [ map { $slurm_job_id.'['.$_.']' } (1..$required_worker_count) ] : [ $slurm_job_id]); 


### PR DESCRIPTION
Remove a redundant message in the Slurm meadow that is already printed by beekeeper.