### PR TITLE
Mbarba/fix capture error

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
@@ -480,7 +480,7 @@ sub submit_workers_return_meadow_pids {
 
     # execute written file + capture STDOUT and EXIT CODE 
     my  ($stdout, $stderr, $exit) = capture {
-       system ("sh $tmp") && die "Could not submit job(s): $!, $?";  # let's abort the beekeeper and let the user check the syntax  
+       system ("sh $tmp");
     };
 
     if ( $exit ne 0 ) {  


### PR DESCRIPTION
## Use case

The die within the capture after the system call uses both $! and $?. If the command fails,
this might raise some errors like:

`Could not submit job(s): Inappropriate ioctl for device, 256 at ...`

The actual problem is not displayed.

## Description

Remove the die() within the capture. If the command fails, the stderr and stdout are properly captured afterwards and displayed.

## Possible Drawbacks

Unlikely.

## Testing

Run the test suite, no difference with previous commit.
