### PR TITLE
Restrain using DBD::mysql version 5.x

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'DBD::SQLite';
 requires 'DBD::Pg';
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
+requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
 requires 'DBD::SQLite';
 requires 'DBD::Pg';
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2024] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

DBD::mysql have released new version (5.001) on Oct 4, 2023. This version removes support for MySQL 5 -
https://metacpan.org/dist/DBD-mysql/changes

Hence we need to use lower version than that.

## Use case

Using DBAdaptors to connect to Ensembl databases which use MySQL version 5

## Possible Drawbacks

Should be changed back if anytime in the future Ensembl database servers upgraded to MySQL 8x.

## Testing

Unit test should pass on this PR
