### PR TITLE
Restrain using DBD::mysql version 5.x

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'DBD::SQLite';
 requires 'DBD::Pg';
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
+requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
 requires 'DBD::SQLite';
 requires 'DBD::Pg';
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,74 @@
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Generic configuration
+[project]
+name = "ensembl-hive"
+dynamic = [
+    "version",
+]
+requires-python = ">= 3.8"
+description = "Ensembl Python Base Hive Wrapper"
+readme = "README.md"
+authors = [
+    {name = "Ensembl", email = "dev@ensembl.org"},
+]
+license = {text = "Apache License 2.0"}
+keywords = [
+    "ehive",
+    "ensembl",
+    "bioinformatics",
+    "workflow",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+# dependencies = []
+
+[project.urls]
+homepage = "https://www.ensembl.org"
+repository = "https://github.com/Ensembl/ensembl-hive"
+
+# [project.scripts]
+# Python entry-points
+
+[tool.setuptools]
+package-dir = {"" = "wrappers/python3"}
+
+[tool.setuptools.dynamic]
+version = {attr = "eHive.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["wrappers/python3"]  # list of folders that contain the packages (["."] by default)
+
+# For additional information on `setuptools` configuration see:
+#    https://setuptools.pypa.io/en/latest/userguide/quickstart.html
+#    https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+#    https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+
+[build-system]
+requires = [
+    "setuptools",
+    "setuptools-scm",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -12,33 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""setuptools based stub for the "editable" installations"""
 
-from pathlib import Path
+from setuptools import setup
 
-from setuptools import setup, find_packages
 
-from wrappers.python3 import eHive
-
-setup(
-    name='ensembl-hive',
-    package_dir={"": "wrappers/python3/"},
-    packages=find_packages(where='wrappers/python3/'),
-    description="Ensembl Python Base Hive Wrapper",
-    author='Ensembl',
-    author_email='dev@ensembl.org',
-    url='https://www.ensembl.org',
-    download_url='https://github.com/Ensembl/ensembl-hive',
-    license='Apache License, Version 2.0',
-    version=eHive.__version__,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Natural Language :: English",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.5",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Description

Sister to PR #215 

DBD::mysql have released new version (5.001) on Oct 4, 2023. This version removes support for MySQL 5 -
https://metacpan.org/dist/DBD-mysql/changes

Hence we need to use lower version than that.

Also, included contents of PR #212 to add `pyproject.toml` to the target branch.

## Use case

Using DBAdaptors to connect to Ensembl databases which use MySQL version 5.

Harmonise `main` and `version/2.6` branches as per use of `pyproject.toml` file in the Python configuration system.

## Possible Drawbacks

Should be changed back if anytime in the future Ensembl database servers upgraded to MySQL 8x.

## Testing

Unit test should pass on this PR
