### PR TITLE
Add eHive REST Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ dependencies = [
     "requests >= 2.22.0",
 ]
 
+[project.optional-dependencies]
+cicd = [
+    "pytest",
+    "requests-mock >= 1.8.0",
+]
+
 [project.urls]
 homepage = "https://www.ensembl.org"
 repository = "https://github.com/Ensembl/ensembl-hive"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ name = "ensembl-hive"
 dynamic = [
     "version",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 description = "Ensembl Python Base Hive Wrapper"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-# dependencies = []
+dependencies = [
+    "requests >= 2.22.0",
+]
 
 [project.urls]
 homepage = "https://www.ensembl.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ version = {attr = "eHive.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["wrappers/python3"]  # list of folders that contain the packages (["."] by default)
+exclude = ["tests*"]
 
 # For additional information on `setuptools` configuration see:
 #    https://setuptools.pypa.io/en/latest/userguide/quickstart.html

--- a/wrappers/python3/eHive/__init__.py
+++ b/wrappers/python3/eHive/__init__.py
@@ -29,18 +29,12 @@ Runnables can use the eHive API (like `param()`). See eHive.BaseRunnable
 for the list of available methods.
 """
 
+__version__ = "5.0"
+
 # We take all the interesting classes from both modules, i.e. BaseRunnable and all the exceptions
-from .process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
+from .process import BaseRunnable, CompleteEarlyException, JobFailedException
 from .params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning
 from .rest import logger, HiveRESTClient
 from .tests import testRunnable, DataflowEvent, WarningEvent, CompleteEarlyEvent, FailureEvent
 from .utils import find_module
 
-__all__ = [
-    'BaseRunnable', 'CompleteEarlyException', 'JobFailedException',
-    'ParamException', 'ParamNameException', 'ParamSubstitutionException', 'ParamInfiniteLoopException', 'ParamWarning',
-    'logger', 'HiveRESTClient',
-    'testRunnable', 'DataflowEvent', 'WarningEvent', 'CompleteEarlyEvent', 'FailureEvent',
-    'find_module',
-    '__version__',
-]

--- a/wrappers/python3/eHive/__init__.py
+++ b/wrappers/python3/eHive/__init__.py
@@ -32,12 +32,14 @@ for the list of available methods.
 # We take all the interesting classes from both modules, i.e. BaseRunnable and all the exceptions
 from .process import BaseRunnable, CompleteEarlyException, JobFailedException, __version__
 from .params import ParamException, ParamNameException, ParamSubstitutionException, ParamInfiniteLoopException, ParamWarning
+from .rest import logger, HiveRESTClient
 from .tests import testRunnable, DataflowEvent, WarningEvent, CompleteEarlyEvent, FailureEvent
 from .utils import find_module
 
 __all__ = [
     'BaseRunnable', 'CompleteEarlyException', 'JobFailedException',
     'ParamException', 'ParamNameException', 'ParamSubstitutionException', 'ParamInfiniteLoopException', 'ParamWarning',
+    'logger', 'HiveRESTClient',
     'testRunnable', 'DataflowEvent', 'WarningEvent', 'CompleteEarlyEvent', 'FailureEvent',
     'find_module',
     '__version__',

--- a/wrappers/python3/eHive/process.py
+++ b/wrappers/python3/eHive/process.py
@@ -28,8 +28,6 @@ import warnings
 
 from . import params
 
-__version__ = "5.0"
-
 
 class Job:
     """Dummy class to hold job-related information"""

--- a/wrappers/python3/eHive/rest.py
+++ b/wrappers/python3/eHive/rest.py
@@ -19,7 +19,6 @@ import contextlib
 import logging
 
 import requests
-from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 from .process import BaseRunnable
@@ -62,7 +61,7 @@ class HiveRESTClient(BaseRunnable):
         Returns:
             A new ``requests.Session`` object
         """
-        adapter = HTTPAdapter(
+        adapter = requests.adapters.HTTPAdapter(
             max_retries=Retry(
                 total=self.param("retry"),
                 status_forcelist=self.param("status_retry"),

--- a/wrappers/python3/eHive/rest.py
+++ b/wrappers/python3/eHive/rest.py
@@ -1,0 +1,122 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""REST API to interact with eHive pipelines."""
+
+__all__ = ["logger", "HiveRESTClient"]
+
+import contextlib
+import logging
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+from .process import BaseRunnable
+
+
+logger = logging.getLogger(__name__)
+
+
+class HiveRESTClient(BaseRunnable):
+    """
+    Basic Root class to interact with random REST API in a Hive Pipeline.
+    Allow random call to an API from a Ensembl-Hive Pipeline config file
+    TODO: Authentication, Secured, Files upload.
+
+    """
+
+    available_method = ("post", "get", "put", "patch")
+
+    def param_defaults(self):
+        """
+        Default parameter set
+        :return: dict
+        """
+        return {
+            "payload": {},
+            "headers": {"content-type": "application/json; charset=utf8"},
+            "files": [],
+            "method": "get",
+            "timeout": 1,
+            "retry": 3,
+            "check_status": True,
+            "status_retry": list(Retry.RETRY_AFTER_STATUS_CODES),
+            "method_retry": list(Retry.DEFAULT_ALLOWED_METHODS),
+        }
+
+    def _open_session(self):
+        """Set up an ``HTTPAdapter`` to allow API call retries in case of Networks failures or remote API
+        unavailability.
+
+        Returns:
+            A new ``requests.Session`` object
+        """
+        adapter = HTTPAdapter(
+            max_retries=Retry(
+                total=self.param("retry"),
+                status_forcelist=self.param("status_retry"),
+                allowed_methods=self.param("method_retry"),
+            )
+        )
+        http = requests.Session()
+        http.mount("https://", adapter)
+        http.mount("http://", adapter)
+        return http
+
+    def _close_session(self, session):
+        """
+        Close all potential remaining connections in current Session
+        :return None
+        """
+        session.close()
+
+    @contextlib.contextmanager
+    def _session_scope(self):
+        """Ensure HTTP session is closed after processing code"""
+        session = self._open_session()
+        logger.debug("HTTP Session opened %s", session)
+        try:
+            yield session
+        except requests.HTTPError as e:
+            message = f"Error performing request {self.param('endpoint')}: {e.strerror}"
+            self.warning(message)
+            raise e
+        finally:
+            logger.debug("Closing session")
+            self._close_session(session)
+
+    def fetch_input(self):
+        """
+        Basic call to request parameters specified in pipeline parameters
+        Return response received.
+        """
+        with self._session_scope() as http:
+            response = http.request(
+                self.param_required("method"),
+                self.param_required("endpoint"),
+                headers=self.param("headers"),
+                files=self.param("files"),
+                data=self.param("payload"),
+                timeout=self.param("timeout"),
+            )
+            self.param("response", response)
+
+    def write_output(self):
+        """
+        Added code to process the response received from api call.
+        For easiness, this is supposed to be the only method needing override to process API HTTP response
+        :param response:
+        :return:
+        """
+        self.dataflow({"rest_response": self.param("response").json()}, 1)

--- a/wrappers/python3/tests/test_rest.py
+++ b/wrappers/python3/tests/test_rest.py
@@ -24,12 +24,12 @@ import unittest
 
 import requests_mock
 
-from ensembl.hive.rest import HiveRESTClient
-from ensembl.hive.test import testRunnable, DataflowEvent
+import eHive
+from eHive.rest import HiveRESTClient
 
 
-class TestHiveRest(unittest.TestCase):
-    """Tests `ensembl.hive.rest.HiveRESTClient`"""
+class TestHiveRESTClient(unittest.TestCase):
+    """Tests `eHive.rest.HiveRESTClient`"""
 
     def test_ApiCall200(self):
         """Tests an `HiveRESTClient` eHive runnable"""
@@ -37,13 +37,13 @@ class TestHiveRest(unittest.TestCase):
         mockJSON = {"data": "content"}
         with requests_mock.Mocker() as m:
             m.get(mockURL, json=mockJSON)
-            testRunnable(
+            eHive.tests.testRunnable(
                 self,
                 HiveRESTClient,
                 {
                     "endpoint": mockURL,
                 },
                 [
-                    DataflowEvent({"rest_response": mockJSON}, branch_name_or_code=1),
+                    eHive.tests.DataflowEvent({"rest_response": mockJSON}, branch_name_or_code=1),
                 ],
             )

--- a/wrappers/python3/tests/test_rest.py
+++ b/wrappers/python3/tests/test_rest.py
@@ -9,27 +9,27 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Unit testing of :mod:`hive` module.
+"""Unit testing of `ensembl.hive.rest` module.
 
 The unit testing is divided into one test class per submodule/class found in this module, and one test method
 per public function/class method.
 
 Typical usage example::
 
-    $ pytest hive/test_rest.py
+    $ pytest test_rest.py
 
 """
 
 import unittest
 
-import eHive
 import requests_mock
 
-from ensembl.hive.HiveRESTClient import HiveRESTClient
+from ensembl.hive.rest import HiveRESTClient
+from ensembl.hive.test import testRunnable, DataflowEvent
 
 
 class TestHiveRest(unittest.TestCase):
-    """Tests :class:`~ensembl.hive.HiveRESTClient.HiveRESTClient`"""
+    """Tests `ensembl.hive.rest.HiveRESTClient`"""
 
     def test_ApiCall200(self):
         """Tests an `HiveRESTClient` eHive runnable"""
@@ -37,13 +37,13 @@ class TestHiveRest(unittest.TestCase):
         mockJSON = {"data": "content"}
         with requests_mock.Mocker() as m:
             m.get(mockURL, json=mockJSON)
-            eHive.testRunnable(
+            testRunnable(
                 self,
                 HiveRESTClient,
                 {
                     "endpoint": mockURL,
                 },
                 [
-                    eHive.DataflowEvent({"rest_response": mockJSON}, branch_name_or_code=1),
+                    DataflowEvent({"rest_response": mockJSON}, branch_name_or_code=1),
                 ],
             )

--- a/wrappers/python3/tests/test_rest.py
+++ b/wrappers/python3/tests/test_rest.py
@@ -1,0 +1,49 @@
+# See the NOTICE file distributed with this work for additional information
+#   regarding copyright ownership.
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Unit testing of :mod:`hive` module.
+
+The unit testing is divided into one test class per submodule/class found in this module, and one test method
+per public function/class method.
+
+Typical usage example::
+
+    $ pytest hive/test_rest.py
+
+"""
+
+import unittest
+
+import eHive
+import requests_mock
+
+from ensembl.hive.HiveRESTClient import HiveRESTClient
+
+
+class TestHiveRest(unittest.TestCase):
+    """Tests :class:`~ensembl.hive.HiveRESTClient.HiveRESTClient`"""
+
+    def test_ApiCall200(self):
+        """Tests an `HiveRESTClient` eHive runnable"""
+        mockURL = "http://ensembl.local/api/"
+        mockJSON = {"data": "content"}
+        with requests_mock.Mocker() as m:
+            m.get(mockURL, json=mockJSON)
+            eHive.testRunnable(
+                self,
+                HiveRESTClient,
+                {
+                    "endpoint": mockURL,
+                },
+                [
+                    eHive.DataflowEvent({"rest_response": mockJSON}, branch_name_or_code=1),
+                ],
+            )


### PR DESCRIPTION
## Description

Moving `HiveRESTClient` code from ensembl-py to its rightful placement, including its unit test. I have taken the opportunity to update `pyproject.toml` and move the minimum supported Python version to 3.10.

## Possible Drawbacks

None (to my knowledge).

## Testing

Unit test provided passes successfully.
