### PR TITLE
Add recommonmark for rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-sphinxcontrib-doxylink
-sphinx_rtd_theme
 doxypypy
+sphinxcontrib-doxylink
+sphinx-rtd-theme
+recommonmark


### PR DESCRIPTION
- readthedocs no longer installs some dependencies. Add them explicitly.

They also mention mock, pillow and commonmark, but I believe we do not need those.