### PR TITLE
Adapt to changes in sinfo output

### DIFF
--- a/docs/appendix/changelog.rst
+++ b/docs/appendix/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 *********
 
+Version 2.8.1
+=============
+
+Release overview
+----------------
+
+This version fixes an incompatibility with the Slurm 24 sinfo command.
+
+Changed features and scripts
+------------------------------
+* Adapt to changes in sinfo output
+  
+
 Version 2.8.0
 =============
 

--- a/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/SLURM.pm
@@ -70,10 +70,13 @@ our $VERSION = '5.5';
 # if sinfo gives a version and a non-zero node count.
 sub name {
     # List the slurm version and the cluster node count like "23.02.7:197"
-    my $sinfo = `sinfo -ho "%v:%D" 2>/dev/null`;
-    $sinfo =~ /^(\d+)(?:\.\d+)*:(\d+)$/;
+    my $sversion = `sinfo -V 2>/dev/null`;
+    $sversion =~ /^slurm (\d+)(?:\.\d+)*$/i;
     my $slurm_version = $1;
-    my $node_count = $2;
+
+    my $sinfo = `sinfo -ho "%D" 2>/dev/null`;
+    $sinfo =~ /^(\d+)$/;
+    my $node_count = $1;
 
     if ($slurm_version and $node_count and $slurm_version >= 23 and $node_count > 0) {
         return "slurm";

--- a/modules/Bio/EnsEMBL/Hive/Version.pm
+++ b/modules/Bio/EnsEMBL/Hive/Version.pm
@@ -6,7 +6,7 @@
 
 =head1 SYNOPSIS
 
-    use Bio::EnsEMBL::Hive::Version 2.8.0;
+    use Bio::EnsEMBL::Hive::Version 2.8.1;
 
 =head1 DESCRIPTION
 
@@ -47,7 +47,7 @@ use Exporter 'import';
 our @EXPORT_OK = qw(get_code_version report_versions);
 
 
-our $VERSION = '2.8.0';
+our $VERSION = '2.8.1';
 
 sub get_code_version {
 


### PR DESCRIPTION
- sinfo does not print the slurmd version for each partition, instead giving N/A. We now run 'sinfo -V' separately to get the version.
